### PR TITLE
Harden security, fix pattern matching, add log rotation and session pruning

### DIFF
--- a/agentnanny.py
+++ b/agentnanny.py
@@ -15,6 +15,11 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+try:
+    import tomllib
+except ModuleNotFoundError:
+    tomllib = None  # type: ignore[assignment]
+
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
@@ -173,19 +178,25 @@ def load_config() -> dict:
         "profiles": {k: dict(v) for k, v in BUILTIN_PROFILES.items()},
     }
 
+    def _load_toml(path: Path) -> dict:
+        if tomllib is not None:
+            with open(path, "rb") as fp:
+                return tomllib.load(fp)
+        return parse_toml(path.read_text(encoding="utf-8"))
+
     # Layer 1: script-adjacent config.toml (backward compat)
     if CONFIG_PATH.exists():
-        cfg = _deep_merge(cfg, parse_toml(CONFIG_PATH.read_text(encoding="utf-8")))
+        cfg = _deep_merge(cfg, _load_toml(CONFIG_PATH))
 
     # Layer 2: user config (~/.config/agentnanny/config.toml or %APPDATA%)
     user_path = _user_config_path()
     if user_path.exists():
-        cfg = _deep_merge(cfg, parse_toml(user_path.read_text(encoding="utf-8")))
+        cfg = _deep_merge(cfg, _load_toml(user_path))
 
     # Layer 3: project config (.agentnanny.toml walking up from cwd)
     proj_path = _find_project_config()
     if proj_path is not None:
-        cfg = _deep_merge(cfg, parse_toml(proj_path.read_text(encoding="utf-8")))
+        cfg = _deep_merge(cfg, _load_toml(proj_path))
 
     # Layer 4: env var overrides
     if v := os.environ.get("AGENTNANNY_SESSION"):
@@ -198,6 +209,23 @@ def load_config() -> dict:
         cfg.setdefault("daemon", {})["dry_run"] = v.lower() in ("1", "true", "yes")
 
     return cfg
+
+
+# ---------------------------------------------------------------------------
+# Glob-to-regex conversion
+# ---------------------------------------------------------------------------
+
+
+def _glob_to_regex(pattern: str) -> str:
+    """Convert a glob pattern (with ``|`` alternation) to a regex string.
+
+    Each ``|``-separated segment is converted independently (``*`` → ``.*``,
+    ``?`` → ``.``) and the segments are joined with ``|``.
+    """
+    parts: list[str] = []
+    for segment in pattern.split("|"):
+        parts.append(re.escape(segment).replace(r"\*", ".*").replace(r"\?", "."))
+    return "|".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -223,8 +251,7 @@ def matches_deny(tool_name: str, tool_input: dict, deny_list: list[str]) -> bool
                 continue
             # Match against the primary input field (command for Bash, etc.)
             input_str = _primary_input(tool_name, tool_input)
-            # Convert glob-style to regex
-            regex = re.escape(pat_input).replace(r"\*", ".*").replace(r"\?", ".")
+            regex = _glob_to_regex(pat_input)
             if re.match(regex, input_str):
                 return True
         else:
@@ -266,12 +293,18 @@ def generate_scope_id() -> str:
 
 
 def save_session_policy(policy: dict) -> Path:
-    """Write a session policy file. Returns the path."""
+    """Write a session policy file with hardened permissions. Returns the path."""
     SESSION_DIR.mkdir(parents=True, exist_ok=True)
+    os.chmod(SESSION_DIR, 0o700)
     path = SESSION_DIR / f"{policy['scope_id']}.json"
     tmp = path.with_suffix(".tmp")
-    tmp.write_text(json.dumps(policy, indent=2), encoding="utf-8")
-    tmp.replace(path)
+    data = json.dumps(policy, indent=2).encode("utf-8")
+    fd = os.open(str(tmp), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, data)
+    finally:
+        os.close(fd)
+    os.replace(str(tmp), str(path))
     return path
 
 
@@ -380,7 +413,7 @@ def matches_allow(tool_name: str, tool_input: dict, allow_patterns: list[str]) -
             if pat_tool != tool_name:
                 continue
             input_str = _primary_input(tool_name, tool_input)
-            regex = re.escape(pat_input).replace(r"\*", ".*").replace(r"\?", ".")
+            regex = _glob_to_regex(pat_input)
             if re.match(regex, input_str):
                 return True
         else:
@@ -399,12 +432,34 @@ def matches_allow(tool_name: str, tool_input: dict, allow_patterns: list[str]) -
 # ---------------------------------------------------------------------------
 
 
+def _rotate_log(log_path: str, backup_count: int) -> None:
+    """Rotate log files: .log → .log.1, .log.1 → .log.2, etc."""
+    for i in range(backup_count, 0, -1):
+        src = f"{log_path}.{i}" if i > 1 else f"{log_path}.1"
+        dst = f"{log_path}.{i + 1}" if i < backup_count else None
+        # Drop the oldest backup if at limit
+        if i == backup_count and Path(src).exists():
+            Path(src).unlink()
+            continue
+    # Shift existing backups up
+    for i in range(backup_count - 1, 0, -1):
+        src = f"{log_path}.{i}"
+        dst = f"{log_path}.{i + 1}"
+        if Path(src).exists():
+            os.replace(src, dst)
+    # Move current log to .1
+    if Path(log_path).exists():
+        os.replace(log_path, f"{log_path}.1")
+
+
 def audit_log(source: str, action: str, tool_name: str, detail: str, cfg: dict | None = None):
-    """Append a TSV line to the audit log."""
+    """Append a TSV line to the audit log with hardened permissions and size-based rotation."""
     cfg = cfg or load_config()
     log_cfg = cfg.get("logging", {})
     level = log_cfg.get("level", "actions")
     log_path = log_cfg.get("audit_log", "/tmp/agentnanny.log")
+    max_size_bytes = int(log_cfg.get("max_size_bytes", 10485760))
+    backup_count = int(log_cfg.get("backup_count", 3))
 
     if level == "actions" and action not in ("allowed", "denied", "approved", "expanded"):
         return
@@ -412,8 +467,16 @@ def audit_log(source: str, action: str, tool_name: str, detail: str, cfg: dict |
     ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
     line = f"{ts}\t{source}\t{action}\t{tool_name}\t{detail}\n"
     try:
-        with open(log_path, "a", encoding="utf-8") as f:
-            f.write(line)
+        # Size-based rotation
+        p = Path(log_path)
+        if p.exists() and p.stat().st_size >= max_size_bytes:
+            _rotate_log(log_path, backup_count)
+        # Open with hardened permissions (0o600)
+        fd = os.open(log_path, os.O_CREAT | os.O_WRONLY | os.O_APPEND, 0o600)
+        try:
+            os.write(fd, line.encode("utf-8"))
+        finally:
+            os.close(fd)
     except OSError:
         pass  # Log failure is not fatal
 
@@ -1026,6 +1089,21 @@ def cmd_activate(profile: str | None, groups: str | None, tools: str | None,
     if group_names:
         resolve_groups(group_names, cfg)
 
+    # Validate deny pattern syntax
+    for pat in deny_patterns:
+        m_pat = re.match(r'^(\w+)\((.+)\)$', pat)
+        if m_pat:
+            try:
+                re.compile(_glob_to_regex(m_pat.group(2)))
+            except re.error as exc:
+                raise ValueError(f"Invalid deny pattern {pat!r}: {exc}") from exc
+        else:
+            # Plain pattern is used as regex in fullmatch — validate it
+            try:
+                re.compile(pat)
+            except re.error as exc:
+                raise ValueError(f"Invalid deny pattern {pat!r}: {exc}") from exc
+
     scope_id = generate_scope_id()
     policy = {
         "scope_id": scope_id,
@@ -1184,6 +1262,30 @@ def cmd_sessions():
         print(f"{scope_id}  age={age}s  {ttl_str}  groups=[{groups}]  tools=[{tools}]")
 
 
+def cmd_prune():
+    """Remove expired session policy files."""
+    if not SESSION_DIR.exists():
+        print("No sessions directory")
+        return
+    now = datetime.now(timezone.utc)
+    removed = 0
+    for path in SESSION_DIR.glob("*.json"):
+        try:
+            policy = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            path.unlink(missing_ok=True)
+            removed += 1
+            continue
+        ttl = policy.get("ttl_seconds", 0)
+        if ttl > 0:
+            created = datetime.fromisoformat(policy["created"])
+            elapsed = (now - created).total_seconds()
+            if elapsed > ttl:
+                path.unlink(missing_ok=True)
+                removed += 1
+    print(f"Pruned {removed} expired session(s)")
+
+
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
@@ -1231,6 +1333,7 @@ def main():
 
     sub.add_parser("profiles", help="List available profiles")
     sub.add_parser("sessions", help="List active session policies")
+    sub.add_parser("prune", help="Remove expired session files")
 
     args = parser.parse_args()
 
@@ -1262,6 +1365,8 @@ def main():
         cmd_list_profiles()
     elif args.command == "sessions":
         cmd_sessions()
+    elif args.command == "prune":
+        cmd_prune()
     else:
         parser.print_help()
         raise SystemExit(1)

--- a/config.toml
+++ b/config.toml
@@ -74,3 +74,5 @@ dry_run = false
 audit_log = "/tmp/agentnanny.log"
 # "all" logs every decision, "actions" logs only allows/denies
 level = "actions"
+max_size_bytes = 10485760
+backup_count = 3

--- a/test_agentnanny.py
+++ b/test_agentnanny.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import json
 import os
+import re
+import stat
 import subprocess
 import sys
 import textwrap
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
@@ -1814,3 +1816,313 @@ class TestInit:
         content = (tmp_path / ".agentnanny.toml").read_text()
         result = agentnanny.parse_toml(content)
         assert "hooks" in result
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# File permissions hardening
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestFilePermissions:
+    def test_save_session_creates_file_0600(self, tmp_path):
+        sess_dir = tmp_path / "sessions"
+        with patch.object(agentnanny, "SESSION_DIR", sess_dir):
+            policy = {
+                "scope_id": "be001234",
+                "created": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                "ttl_seconds": 3600,
+                "allow_groups": ["shell"],
+                "allow_tools": [],
+                "deny": [],
+            }
+            path = agentnanny.save_session_policy(policy)
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode == 0o600
+
+    def test_save_session_creates_dir_0700(self, tmp_path):
+        sess_dir = tmp_path / "sessions"
+        with patch.object(agentnanny, "SESSION_DIR", sess_dir):
+            policy = {
+                "scope_id": "face1234",
+                "created": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                "ttl_seconds": 3600,
+                "allow_groups": [],
+                "allow_tools": [],
+                "deny": [],
+            }
+            agentnanny.save_session_policy(policy)
+        mode = stat.S_IMODE(sess_dir.stat().st_mode)
+        assert mode == 0o700
+
+    def test_save_session_no_world_readable_tmp(self, tmp_path):
+        sess_dir = tmp_path / "sessions"
+        with patch.object(agentnanny, "SESSION_DIR", sess_dir):
+            policy = {
+                "scope_id": "a0b1c2d3",
+                "created": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                "ttl_seconds": 3600,
+                "allow_groups": [],
+                "allow_tools": [],
+                "deny": [],
+            }
+            agentnanny.save_session_policy(policy)
+        # tmp file should not exist after replace
+        tmp_file = sess_dir / "a0b1c2d3.tmp"
+        assert not tmp_file.exists()
+        # Final file should be 0o600
+        final = sess_dir / "a0b1c2d3.json"
+        mode = stat.S_IMODE(final.stat().st_mode)
+        assert mode == 0o600
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Glob-to-regex conversion
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestGlobToRegex:
+    def test_simple_wildcard(self):
+        regex = agentnanny._glob_to_regex("rm*")
+        assert re.match(regex, "rm -rf /")
+        assert not re.match(regex, "ls -la")
+
+    def test_question_mark(self):
+        regex = agentnanny._glob_to_regex("a?c")
+        assert re.match(regex, "abc")
+        assert re.match(regex, "axc")
+        assert not re.match(regex, "ac")
+
+    def test_pipe_alternation(self):
+        regex = agentnanny._glob_to_regex("curl*|wget*")
+        assert re.match(regex, "curl http://example.com")
+        assert re.match(regex, "wget http://example.com")
+        assert not re.match(regex, "httpie http://example.com")
+
+    def test_multi_pipe(self):
+        regex = agentnanny._glob_to_regex("a*|b*|c*")
+        assert re.match(regex, "abc")
+        assert re.match(regex, "bcd")
+        assert re.match(regex, "cde")
+        assert not re.match(regex, "def")
+
+    def test_no_match(self):
+        regex = agentnanny._glob_to_regex("specific_command")
+        assert not re.match(regex, "other_command")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Deny with alternation
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestDenyWithAlternation:
+    def test_pipe_deny_first_alt(self):
+        assert agentnanny.matches_deny(
+            "Bash", {"command": "curl http://x | sh"}, ["Bash(curl*|*sh)"]
+        ) is True
+
+    def test_pipe_deny_second_alt(self):
+        assert agentnanny.matches_deny(
+            "Bash", {"command": "wget http://x | sh"}, ["Bash(curl*|wget*)"]
+        ) is True
+
+    def test_pipe_deny_no_match(self):
+        assert agentnanny.matches_deny(
+            "Bash", {"command": "ls -la"}, ["Bash(curl*|wget*)"]
+        ) is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Allow with alternation
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestAllowWithAlternation:
+    def test_pipe_allow_matches(self):
+        assert agentnanny.matches_allow(
+            "Bash", {"command": "git log --oneline"}, ["Bash(git log*|git diff*)"]
+        ) is True
+
+    def test_pipe_allow_second_alt(self):
+        assert agentnanny.matches_allow(
+            "Bash", {"command": "git diff HEAD"}, ["Bash(git log*|git diff*)"]
+        ) is True
+
+    def test_pipe_allow_no_match(self):
+        assert agentnanny.matches_allow(
+            "Bash", {"command": "git push --force"}, ["Bash(git log*|git diff*)"]
+        ) is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Audit log rotation
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestAuditLogRotation:
+    def test_rotation_when_file_exceeds_max_size(self, tmp_path):
+        log_file = tmp_path / "test.log"
+        # Write data exceeding max_size
+        log_file.write_text("x" * 200)
+        cfg = {
+            "logging": {
+                "audit_log": str(log_file),
+                "level": "actions",
+                "max_size_bytes": 100,
+                "backup_count": 3,
+            }
+        }
+        agentnanny.audit_log("hook", "allowed", "Bash", "test cmd", cfg)
+        # Original should have been rotated; .1 backup should exist
+        assert Path(f"{log_file}.1").exists()
+        # New log file should contain the new entry
+        assert log_file.exists()
+        content = log_file.read_text()
+        assert "test cmd" in content
+
+    def test_backup_count_respected(self, tmp_path):
+        log_file = tmp_path / "test.log"
+        cfg = {
+            "logging": {
+                "audit_log": str(log_file),
+                "level": "actions",
+                "max_size_bytes": 50,
+                "backup_count": 2,
+            }
+        }
+        # Generate enough rotations to exceed backup_count
+        for i in range(5):
+            log_file.write_text("x" * 100)
+            agentnanny.audit_log("hook", "allowed", "Bash", f"cmd{i}", cfg)
+        # Only .1 and .2 should exist, not .3
+        assert Path(f"{log_file}.1").exists()
+        assert Path(f"{log_file}.2").exists()
+        assert not Path(f"{log_file}.3").exists()
+
+    def test_no_rotation_when_under_max_size(self, tmp_path):
+        log_file = tmp_path / "test.log"
+        log_file.write_text("small")
+        cfg = {
+            "logging": {
+                "audit_log": str(log_file),
+                "level": "actions",
+                "max_size_bytes": 10485760,
+                "backup_count": 3,
+            }
+        }
+        agentnanny.audit_log("hook", "allowed", "Bash", "test", cfg)
+        assert not Path(f"{log_file}.1").exists()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Prune command
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestPrune:
+    def test_prune_removes_expired(self, tmp_path, capsys):
+        sess_dir = tmp_path / "sessions"
+        sess_dir.mkdir()
+        # Expired session
+        expired_policy = {
+            "scope_id": "be001234",
+            "created": (datetime.now(timezone.utc) - timedelta(hours=10)).isoformat(timespec="seconds"),
+            "ttl_seconds": 3600,
+            "allow_groups": [],
+            "allow_tools": [],
+            "deny": [],
+        }
+        (sess_dir / "be001234.json").write_text(json.dumps(expired_policy))
+        with patch.object(agentnanny, "SESSION_DIR", sess_dir):
+            agentnanny.cmd_prune()
+        assert not (sess_dir / "be001234.json").exists()
+        out = capsys.readouterr().out
+        assert "1" in out
+
+    def test_prune_keeps_valid(self, tmp_path, capsys):
+        sess_dir = tmp_path / "sessions"
+        sess_dir.mkdir()
+        # Valid session (not expired)
+        valid_policy = {
+            "scope_id": "face1234",
+            "created": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "ttl_seconds": 36000,
+            "allow_groups": ["shell"],
+            "allow_tools": [],
+            "deny": [],
+        }
+        (sess_dir / "face1234.json").write_text(json.dumps(valid_policy))
+        with patch.object(agentnanny, "SESSION_DIR", sess_dir):
+            agentnanny.cmd_prune()
+        assert (sess_dir / "face1234.json").exists()
+        out = capsys.readouterr().out
+        assert "0" in out
+
+    def test_prune_no_sessions_dir(self, tmp_path, capsys):
+        sess_dir = tmp_path / "nonexistent"
+        with patch.object(agentnanny, "SESSION_DIR", sess_dir):
+            agentnanny.cmd_prune()
+        out = capsys.readouterr().out
+        assert "No sessions" in out
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Pattern validation on activate
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestPatternValidation:
+    def test_invalid_deny_pattern_raises(self):
+        cfg = {
+            "hooks": {},
+            "groups": dict(agentnanny.BUILTIN_GROUPS),
+            "profiles": {k: dict(v) for k, v in agentnanny.BUILTIN_PROFILES.items()},
+            "logging": {},
+            "daemon": {},
+        }
+        with patch.object(agentnanny, "load_config", return_value=cfg), \
+             patch.object(agentnanny, "generate_scope_id", return_value="a0b1c2d3"), \
+             patch.object(agentnanny, "save_session_policy"):
+            with pytest.raises(ValueError, match="Invalid deny pattern"):
+                agentnanny.cmd_activate(None, "shell", None, "[invalid", None)
+
+    def test_valid_deny_pattern_succeeds(self, capsys):
+        cfg = {
+            "hooks": {},
+            "groups": dict(agentnanny.BUILTIN_GROUPS),
+            "profiles": {k: dict(v) for k, v in agentnanny.BUILTIN_PROFILES.items()},
+            "logging": {},
+            "daemon": {},
+        }
+        with patch.object(agentnanny, "load_config", return_value=cfg), \
+             patch.object(agentnanny, "generate_scope_id", return_value="a0b1c2d3"), \
+             patch.object(agentnanny, "save_session_policy", return_value=Path("/tmp/fake")):
+            agentnanny.cmd_activate(None, "shell", None, "Bash(rm*|dd*)", None)
+        out = capsys.readouterr().out
+        assert "AGENTNANNY_SCOPE" in out
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# tomllib usage on Python 3.11+
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestTomlLib:
+    def test_tomllib_used_when_available(self, tmp_path):
+        config = tmp_path / "config.toml"
+        config.write_text('[daemon]\nsession = "test"\n')
+        with patch.object(agentnanny, "CONFIG_PATH", config), \
+             patch.object(agentnanny, "_user_config_path", return_value=tmp_path / "noexist"), \
+             patch.object(agentnanny, "_find_project_config", return_value=None):
+            cfg = agentnanny.load_config()
+        assert cfg["daemon"]["session"] == "test"
+
+    def test_fallback_to_parse_toml_when_no_tomllib(self, tmp_path):
+        config = tmp_path / "config.toml"
+        config.write_text('[daemon]\nsession = "fallback"\n')
+        with patch.object(agentnanny, "tomllib", None), \
+             patch.object(agentnanny, "CONFIG_PATH", config), \
+             patch.object(agentnanny, "_user_config_path", return_value=tmp_path / "noexist"), \
+             patch.object(agentnanny, "_find_project_config", return_value=None):
+            cfg = agentnanny.load_config()
+        assert cfg["daemon"]["session"] == "fallback"


### PR DESCRIPTION
## Summary
Six security and maintenance improvements:

- **File permission hardening** — session files created with `0o600`, session dir with `0o700`, audit log with `0o600` via `os.open()` instead of `write_text()`/`open()`
- **Glob alternation fix** — extracted `_glob_to_regex()` supporting `|` alternation in patterns (e.g., `Bash(curl*|*sh)`), used by both `matches_deny()` and `matches_allow()`
- **Audit log rotation** — rotates when file exceeds `max_size_bytes` (default 10MB), keeps `backup_count` (default 3) old files
- **Prune subcommand** — `agentnanny.py prune` removes expired session files
- **tomllib support** — uses `tomllib` on Python 3.11+ for robust TOML parsing, falls back to built-in parser
- **Pattern validation** — validates deny pattern syntax at activation time, fails fast on invalid regex

## Test plan
- 24 new tests across 8 test classes
- All 197 tests pass (173 existing + 24 new)