### PR TITLE
Add structured audit log with filtering and format options

### DIFF
--- a/agentnanny.py
+++ b/agentnanny.py
@@ -969,18 +969,68 @@ def show_status():
         print(f"Session policies: {len(policies)} active")
 
 
-def show_log():
-    """Tail the audit log."""
+def show_log(
+    lines_count: int = 50,
+    output_format: str = "raw",
+    filter_tool: str | None = None,
+    filter_action: str | None = None,
+) -> None:
+    """Show the audit log with optional filtering and formatting."""
     cfg = load_config()
     log_path = cfg.get("logging", {}).get("audit_log", "/tmp/agentnanny.log")
     if not Path(log_path).exists():
         print(f"No log file at {log_path}")
         return
     with open(log_path, encoding="utf-8") as f:
-        lines = f.readlines()
-    # Show last 50 lines
-    for line in lines[-50:]:
-        print(line, end="")
+        raw_lines = f.readlines()
+
+    # Parse TSV lines into structured records
+    records: list[dict[str, str]] = []
+    for line in raw_lines:
+        line = line.rstrip("\n")
+        if not line:
+            continue
+        parts = line.split("\t")
+        if len(parts) < 5:
+            continue
+        record = {
+            "timestamp": parts[0],
+            "source": parts[1],
+            "action": parts[2],
+            "tool_name": parts[3],
+            "detail": parts[4],
+        }
+        if filter_tool and record["tool_name"] != filter_tool:
+            continue
+        if filter_action and record["action"] != filter_action:
+            continue
+        records.append(record)
+
+    # Limit to last N records
+    records = records[-lines_count:]
+
+    if not records:
+        print("No matching log entries.")
+        return
+
+    if output_format == "json":
+        print(json.dumps(records, indent=2))
+    elif output_format == "table":
+        headers = ["TIMESTAMP", "SOURCE", "ACTION", "TOOL", "DETAIL"]
+        keys = ["timestamp", "source", "action", "tool_name", "detail"]
+        col_widths = [len(h) for h in headers]
+        for rec in records:
+            for i, key in enumerate(keys):
+                col_widths[i] = max(col_widths[i], len(rec[key]))
+        fmt = "  ".join(f"{{:<{w}}}" for w in col_widths)
+        print(fmt.format(*headers))
+        print(fmt.format(*("-" * w for w in col_widths)))
+        for rec in records:
+            print(fmt.format(*(rec[k] for k in keys)))
+    else:
+        # raw: original TSV lines
+        for rec in records:
+            print("\t".join(rec[k] for k in ["timestamp", "source", "action", "tool_name", "detail"]))
 
 
 # ---------------------------------------------------------------------------
@@ -1209,7 +1259,11 @@ def main():
     sub.add_parser("stop", help="Stop tmux daemon")
     sub.add_parser("init", help="Create .agentnanny.toml in current directory")
     sub.add_parser("status", help="Show hook + daemon status")
-    sub.add_parser("log", help="Tail audit log")
+    p_log = sub.add_parser("log", help="Tail audit log")
+    p_log.add_argument("--lines", "-n", type=int, default=50, help="Number of lines to show (default: 50)")
+    p_log.add_argument("--format", "-f", dest="log_format", choices=["raw", "json", "table"], default="raw", help="Output format (default: raw)")
+    p_log.add_argument("--tool", default=None, help="Filter by tool name")
+    p_log.add_argument("--action", default=None, help="Filter by action")
 
     p_activate = sub.add_parser("activate", help="Create a session policy (prints export command)")
     p_activate.add_argument("profile", nargs="?", default=None, help="Profile name (e.g. safe-dev)")
@@ -1251,7 +1305,12 @@ def main():
     elif args.command == "status":
         show_status()
     elif args.command == "log":
-        show_log()
+        show_log(
+            lines_count=args.lines,
+            output_format=args.log_format,
+            filter_tool=args.tool,
+            filter_action=args.action,
+        )
     elif args.command == "activate":
         cmd_activate(args.profile, args.groups, args.tools, args.deny, args.ttl)
     elif args.command == "deactivate":

--- a/test_agentnanny.py
+++ b/test_agentnanny.py
@@ -1814,3 +1814,117 @@ class TestInit:
         content = (tmp_path / ".agentnanny.toml").read_text()
         result = agentnanny.parse_toml(content)
         assert "hooks" in result
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# show_log
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+SAMPLE_LOG_LINES = [
+    "2026-01-01T00:00:00+00:00\thook\tallowed\tBash\tcommand=ls\n",
+    "2026-01-01T00:00:01+00:00\thook\tdenied\tWrite\tpath=/etc/passwd\n",
+    "2026-01-01T00:00:02+00:00\tdaemon\tapproved\tcontinue\tpane=%0\n",
+    "2026-01-01T00:00:03+00:00\thook\tallowed\tRead\tpath=foo.py\n",
+    "2026-01-01T00:00:04+00:00\thook\tdenied\tBash\tcommand=rm -rf /\n",
+]
+
+
+class TestShowLog:
+    def _write_log(self, tmp_path: Path, lines: list[str] | None = None) -> str:
+        log_file = tmp_path / "test.log"
+        log_file.write_text("".join(lines or SAMPLE_LOG_LINES), encoding="utf-8")
+        return str(log_file)
+
+    def test_raw_format(self, tmp_path, capsys):
+        log_path = self._write_log(tmp_path)
+        with patch.object(agentnanny, "load_config", return_value={"logging": {"audit_log": log_path}}):
+            agentnanny.show_log(output_format="raw")
+        out = capsys.readouterr().out
+        assert "Bash" in out
+        assert "\t" in out
+        lines = [l for l in out.strip().splitlines() if l]
+        assert len(lines) == 5
+
+    def test_json_format(self, tmp_path, capsys):
+        log_path = self._write_log(tmp_path)
+        with patch.object(agentnanny, "load_config", return_value={"logging": {"audit_log": log_path}}):
+            agentnanny.show_log(output_format="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert isinstance(data, list)
+        assert len(data) == 5
+        assert data[0]["timestamp"] == "2026-01-01T00:00:00+00:00"
+        assert data[0]["source"] == "hook"
+        assert data[0]["action"] == "allowed"
+        assert data[0]["tool_name"] == "Bash"
+        assert data[0]["detail"] == "command=ls"
+
+    def test_table_format(self, tmp_path, capsys):
+        log_path = self._write_log(tmp_path)
+        with patch.object(agentnanny, "load_config", return_value={"logging": {"audit_log": log_path}}):
+            agentnanny.show_log(output_format="table")
+        out = capsys.readouterr().out
+        lines = out.strip().splitlines()
+        # Header + separator + 5 data rows
+        assert len(lines) == 7
+        assert "TIMESTAMP" in lines[0]
+        assert "SOURCE" in lines[0]
+        assert "ACTION" in lines[0]
+        assert "TOOL" in lines[0]
+        assert "DETAIL" in lines[0]
+        assert "---" in lines[1]
+
+    def test_filter_by_tool(self, tmp_path, capsys):
+        log_path = self._write_log(tmp_path)
+        with patch.object(agentnanny, "load_config", return_value={"logging": {"audit_log": log_path}}):
+            agentnanny.show_log(output_format="json", filter_tool="Bash")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert len(data) == 2
+        assert all(r["tool_name"] == "Bash" for r in data)
+
+    def test_filter_by_action(self, tmp_path, capsys):
+        log_path = self._write_log(tmp_path)
+        with patch.object(agentnanny, "load_config", return_value={"logging": {"audit_log": log_path}}):
+            agentnanny.show_log(output_format="json", filter_action="denied")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert len(data) == 2
+        assert all(r["action"] == "denied" for r in data)
+
+    def test_combined_filters(self, tmp_path, capsys):
+        log_path = self._write_log(tmp_path)
+        with patch.object(agentnanny, "load_config", return_value={"logging": {"audit_log": log_path}}):
+            agentnanny.show_log(output_format="json", filter_tool="Bash", filter_action="denied")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert len(data) == 1
+        assert data[0]["tool_name"] == "Bash"
+        assert data[0]["action"] == "denied"
+
+    def test_lines_limit(self, tmp_path, capsys):
+        log_path = self._write_log(tmp_path)
+        with patch.object(agentnanny, "load_config", return_value={"logging": {"audit_log": log_path}}):
+            agentnanny.show_log(lines_count=2, output_format="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert len(data) == 2
+        # Should be the last 2 entries
+        assert data[0]["tool_name"] == "Read"
+        assert data[1]["tool_name"] == "Bash"
+
+    def test_empty_log(self, tmp_path, capsys):
+        # Missing log file
+        with patch.object(agentnanny, "load_config", return_value={"logging": {"audit_log": str(tmp_path / "nonexistent.log")}}):
+            agentnanny.show_log()
+        out = capsys.readouterr().out
+        assert "No log file" in out
+
+        # Empty log file
+        empty_log = tmp_path / "empty.log"
+        empty_log.write_text("", encoding="utf-8")
+        with patch.object(agentnanny, "load_config", return_value={"logging": {"audit_log": str(empty_log)}}):
+            agentnanny.show_log()
+        out = capsys.readouterr().out
+        assert "No matching log entries" in out


### PR DESCRIPTION
## Summary
Enhanced `show_log()` with:
- `--lines/-n` — number of entries to show (default 50)
- `--format/-f` — output format: `raw` (TSV), `json` (JSON array), `table` (aligned columns)
- `--tool` — filter by tool name
- `--action` — filter by action (allowed/denied/approved/etc.)

Enables programmatic log consumption via JSON and quick troubleshooting via filtered views.

## Test plan
- `TestShowLog`: 8 tests (raw/json/table formats, tool/action/combined filters, line limit, empty log)
- All 181 tests pass