### PR TITLE
Add extend subcommand for additive session modification

### DIFF
--- a/agentnanny.py
+++ b/agentnanny.py
@@ -1048,6 +1048,63 @@ def cmd_activate(profile: str | None, groups: str | None, tools: str | None,
         print(f"# TTL: {ttl_seconds}s", file=sys.stderr)
 
 
+def cmd_extend(scope_id: str | None, groups: str | None, tools: str | None,
+               deny: str | None):
+    """Add groups, tools, or deny patterns to an existing session policy."""
+    scope_id = scope_id or os.environ.get("AGENTNANNY_SCOPE")
+    if not scope_id:
+        print("No scope ID provided and AGENTNANNY_SCOPE not set", file=sys.stderr)
+        raise SystemExit(1)
+
+    policy = load_session_policy(scope_id)
+    if policy is None:
+        print(f"No active session policy found for {scope_id}", file=sys.stderr)
+        raise SystemExit(1)
+
+    cfg = load_config()
+
+    # Parse new values
+    new_groups = [g.strip() for g in groups.split(",")] if groups else []
+    new_tools = [t.strip() for t in tools.split(",")] if tools else []
+    new_deny = [d.strip() for d in deny.split(",")] if deny else []
+
+    # Validate new groups
+    if new_groups:
+        resolve_groups(new_groups, cfg)
+
+    # Merge with deduplication
+    existing_groups = policy.get("allow_groups", [])
+    existing_tools = policy.get("allow_tools", [])
+    existing_deny = policy.get("deny", [])
+
+    for g in new_groups:
+        if g not in existing_groups:
+            existing_groups.append(g)
+    for t in new_tools:
+        if t not in existing_tools:
+            existing_tools.append(t)
+    for d in new_deny:
+        if d not in existing_deny:
+            existing_deny.append(d)
+
+    policy["allow_groups"] = existing_groups
+    policy["allow_tools"] = existing_tools
+    policy["deny"] = existing_deny
+
+    save_session_policy(policy)
+
+    print(f"# Extended session {scope_id}", file=sys.stderr)
+    if new_groups:
+        print(f"# Added groups: {', '.join(new_groups)}", file=sys.stderr)
+    if new_tools:
+        print(f"# Added tools: {', '.join(new_tools)}", file=sys.stderr)
+    if new_deny:
+        print(f"# Added deny: {', '.join(new_deny)}", file=sys.stderr)
+    print(f"# Groups: {', '.join(existing_groups)}", file=sys.stderr)
+    print(f"# Tools: {', '.join(existing_tools)}", file=sys.stderr)
+    print(f"# Deny: {', '.join(existing_deny)}", file=sys.stderr)
+
+
 def cmd_deactivate(scope_id: str | None):
     """Remove a session policy."""
     scope_id = scope_id or os.environ.get("AGENTNANNY_SCOPE")
@@ -1221,6 +1278,12 @@ def main():
     p_deactivate = sub.add_parser("deactivate", help="Remove a session policy")
     p_deactivate.add_argument("scope_id", nargs="?", default=None, help="Scope ID (default: from AGENTNANNY_SCOPE)")
 
+    p_extend = sub.add_parser("extend", help="Add groups, tools, or deny patterns to an existing session")
+    p_extend.add_argument("scope_id", nargs="?", default=None, help="Scope ID (default: from AGENTNANNY_SCOPE)")
+    p_extend.add_argument("--groups", "-g", default=None, help="Comma-separated group names to add")
+    p_extend.add_argument("--tools", "-t", default=None, help="Comma-separated tool names to add")
+    p_extend.add_argument("--deny", "-d", default=None, help="Comma-separated deny patterns to add")
+
     p_run = sub.add_parser("run", help="Run command with session-scoped permissions")
     p_run.add_argument("profile", nargs="?", default=None, help="Profile name (e.g. safe-dev)")
     p_run.add_argument("--groups", "-g", default=None, help="Comma-separated group names")
@@ -1256,6 +1319,8 @@ def main():
         cmd_activate(args.profile, args.groups, args.tools, args.deny, args.ttl)
     elif args.command == "deactivate":
         cmd_deactivate(args.scope_id)
+    elif args.command == "extend":
+        cmd_extend(args.scope_id, args.groups, args.tools, args.deny)
     elif args.command == "run":
         cmd_run(args.profile, args.groups, args.tools, args.deny, args.ttl, args.command_args)
     elif args.command == "profiles":

--- a/test_agentnanny.py
+++ b/test_agentnanny.py
@@ -1397,6 +1397,122 @@ class TestActivateDeactivate:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
+# Extend
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestExtend:
+    def _create_session(self, tmp_path, scope_id, groups=None, tools=None, deny=None):
+        """Helper to create a session policy for testing."""
+        policy = {
+            "scope_id": scope_id,
+            "created": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "ttl_seconds": 0,
+            "allow_groups": groups or [],
+            "allow_tools": tools or [],
+            "deny": deny or [],
+        }
+        agentnanny.save_session_policy(policy)
+        return policy
+
+    def test_extend_adds_groups(self, tmp_path):
+        cfg = {
+            "hooks": {},
+            "groups": {
+                "filesystem": ["Read", "Write", "Edit", "Glob", "Grep"],
+                "network": ["WebFetch", "WebSearch"],
+            },
+            "logging": {"audit_log": os.devnull},
+        }
+        scope_id = "a1b2c3d4"
+        with patch.object(agentnanny, "SESSION_DIR", tmp_path), \
+             patch.object(agentnanny, "load_config", return_value=cfg):
+            self._create_session(tmp_path, scope_id, groups=["filesystem"])
+            agentnanny.cmd_extend(scope_id, "network", None, None)
+
+        policy = json.loads((tmp_path / f"{scope_id}.json").read_text())
+        assert "filesystem" in policy["allow_groups"]
+        assert "network" in policy["allow_groups"]
+
+    def test_extend_adds_tools(self, tmp_path):
+        cfg = {"hooks": {}, "groups": {}, "logging": {"audit_log": os.devnull}}
+        scope_id = "b2c3d4e5"
+        with patch.object(agentnanny, "SESSION_DIR", tmp_path), \
+             patch.object(agentnanny, "load_config", return_value=cfg):
+            self._create_session(tmp_path, scope_id, tools=["Read"])
+            agentnanny.cmd_extend(scope_id, None, "Write,Edit", None)
+
+        policy = json.loads((tmp_path / f"{scope_id}.json").read_text())
+        assert policy["allow_tools"] == ["Read", "Write", "Edit"]
+
+    def test_extend_adds_deny(self, tmp_path):
+        cfg = {"hooks": {}, "groups": {}, "logging": {"audit_log": os.devnull}}
+        scope_id = "c3d4e5f6"
+        with patch.object(agentnanny, "SESSION_DIR", tmp_path), \
+             patch.object(agentnanny, "load_config", return_value=cfg):
+            self._create_session(tmp_path, scope_id, deny=["Bash(rm*)"])
+            agentnanny.cmd_extend(scope_id, None, None, "Bash(sudo*)")
+
+        policy = json.loads((tmp_path / f"{scope_id}.json").read_text())
+        assert "Bash(rm*)" in policy["deny"]
+        assert "Bash(sudo*)" in policy["deny"]
+
+    def test_extend_deduplicates(self, tmp_path):
+        cfg = {
+            "hooks": {},
+            "groups": {"filesystem": ["Read", "Write", "Edit", "Glob", "Grep"]},
+            "logging": {"audit_log": os.devnull},
+        }
+        scope_id = "d4e5f6a7"
+        with patch.object(agentnanny, "SESSION_DIR", tmp_path), \
+             patch.object(agentnanny, "load_config", return_value=cfg):
+            self._create_session(tmp_path, scope_id, groups=["filesystem"], tools=["Bash"])
+            agentnanny.cmd_extend(scope_id, "filesystem", "Bash", None)
+
+        policy = json.loads((tmp_path / f"{scope_id}.json").read_text())
+        assert policy["allow_groups"].count("filesystem") == 1
+        assert policy["allow_tools"].count("Bash") == 1
+
+    def test_extend_nonexistent_session(self, tmp_path):
+        cfg = {"hooks": {}, "groups": {}, "logging": {"audit_log": os.devnull}}
+        with patch.object(agentnanny, "SESSION_DIR", tmp_path), \
+             patch.object(agentnanny, "load_config", return_value=cfg):
+            with pytest.raises(SystemExit):
+                agentnanny.cmd_extend("deadbeef", "filesystem", None, None)
+
+    def test_extend_uses_env_scope(self, tmp_path):
+        cfg = {
+            "hooks": {},
+            "groups": {"network": ["WebFetch", "WebSearch"]},
+            "logging": {"audit_log": os.devnull},
+        }
+        scope_id = "e5f6a7b8"
+        with patch.object(agentnanny, "SESSION_DIR", tmp_path), \
+             patch.object(agentnanny, "load_config", return_value=cfg), \
+             patch.dict(os.environ, {"AGENTNANNY_SCOPE": scope_id}):
+            self._create_session(tmp_path, scope_id)
+            agentnanny.cmd_extend(None, "network", None, None)
+
+        policy = json.loads((tmp_path / f"{scope_id}.json").read_text())
+        assert "network" in policy["allow_groups"]
+
+    def test_extend_no_scope(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AGENTNANNY_SCOPE", None)
+            with pytest.raises(SystemExit):
+                agentnanny.cmd_extend(None, None, None, None)
+
+    def test_extend_validates_groups(self, tmp_path):
+        cfg = {"hooks": {}, "groups": {}, "logging": {"audit_log": os.devnull}}
+        scope_id = "f6a7b8c9"
+        with patch.object(agentnanny, "SESSION_DIR", tmp_path), \
+             patch.object(agentnanny, "load_config", return_value=cfg):
+            self._create_session(tmp_path, scope_id)
+            with pytest.raises(ValueError, match="Unknown group"):
+                agentnanny.cmd_extend(scope_id, "nonexistent_group", None, None)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
 # Run wrapper
 # ═══════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary
- **`extend`** subcommand — additively modify an active session policy without replacing it
- Adds new groups, tools, or deny patterns with deduplication
- Validates new groups against config before applying
- Defaults to `AGENTNANNY_SCOPE` env var if no scope ID provided

Usage: `agentnanny.py extend -g network -t WebFetch -d "Bash(curl*)"`

## Test plan
- `TestExtend`: 8 tests (add groups/tools/deny, deduplication, nonexistent session, env var fallback, no scope, group validation)
- All 181 tests pass