### PR TITLE
Add Codex CLI integration

### DIFF
--- a/agentnanny.py
+++ b/agentnanny.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""agentnanny — auto-approve Claude Code permission prompts via hooks + tmux daemon."""
+"""agentnanny — granular permission manager for Claude Code and Codex CLI."""
 
 from __future__ import annotations
 
@@ -30,6 +30,22 @@ SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
 CLAUDE_JSON_PATH = Path.home() / ".claude.json"
 PID_FILE = Path("/tmp/agentnanny.pid") if sys.platform != "win32" else Path(os.environ.get("TEMP", "/tmp")) / "agentnanny.pid"
 SESSION_DIR = Path(tempfile.gettempdir()) / "agentnanny" / "sessions"
+
+# Codex CLI paths
+CODEX_HOME = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+CODEX_CONFIG_PATH = CODEX_HOME / "config.toml"
+
+# Supported targets
+TARGETS = ("claude", "codex")
+
+# Map agentnanny profiles to Codex approval_policy values
+CODEX_APPROVAL_MAP: dict[str, str] = {
+    "reviewer": "unless-trusted",
+    "safe-dev": "unless-trusted",
+    "full-dev": "on-failure",
+    "overnight": "on-failure",
+    "ci-runner": "never",
+}
 
 # ---------------------------------------------------------------------------
 # Built-in groups and profiles (work without any config file)
@@ -492,7 +508,227 @@ def audit_log(source: str, action: str, tool_name: str, detail: str, cfg: dict |
 
 
 # ---------------------------------------------------------------------------
-# Mode 1: Hook handler
+# Codex CLI integration
+# ---------------------------------------------------------------------------
+
+
+def _serialize_toml_value(value: object) -> str:
+    """Serialize a Python value to a TOML-compatible string."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return f'"{value}"'
+    if isinstance(value, int | float):
+        return str(value)
+    if isinstance(value, list):
+        items = ", ".join(_serialize_toml_value(v) for v in value)
+        return f"[{items}]"
+    raise TypeError(f"Unsupported TOML type: {type(value)}")
+
+
+def _patch_codex_config(updates: dict[str, object]) -> Path:
+    """Read ~/.codex/config.toml, apply key=value updates, write back.
+
+    Only touches top-level keys. Preserves existing content and comments
+    by replacing matching lines or appending new ones.
+    """
+    CODEX_HOME.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = []
+    if CODEX_CONFIG_PATH.exists():
+        lines = CODEX_CONFIG_PATH.read_text(encoding="utf-8").splitlines()
+
+    remaining = dict(updates)
+    new_lines: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        matched = False
+        for key in list(remaining):
+            if stripped.startswith(f"{key} ") or stripped.startswith(f"{key}="):
+                new_lines.append(f"{key} = {_serialize_toml_value(remaining.pop(key))}")
+                matched = True
+                break
+        if not matched:
+            new_lines.append(line)
+
+    for key, val in remaining.items():
+        new_lines.append(f"{key} = {_serialize_toml_value(val)}")
+
+    content = "\n".join(new_lines) + "\n"
+    CODEX_CONFIG_PATH.write_text(content, encoding="utf-8")
+    return CODEX_CONFIG_PATH
+
+
+def _remove_codex_config_keys(keys: list[str]) -> bool:
+    """Remove specific top-level keys from ~/.codex/config.toml."""
+    if not CODEX_CONFIG_PATH.exists():
+        return False
+    lines = CODEX_CONFIG_PATH.read_text(encoding="utf-8").splitlines()
+    new_lines = []
+    removed = False
+    for line in lines:
+        stripped = line.strip()
+        if any(stripped.startswith(f"{k} ") or stripped.startswith(f"{k}=") for k in keys):
+            removed = True
+            continue
+        new_lines.append(line)
+    if removed:
+        CODEX_CONFIG_PATH.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+    return removed
+
+
+_BASH_PATTERN_RE = re.compile(r'^Bash\((.+)\)$')
+
+
+def _patterns_to_codex_rules(patterns: list[str], decision: str) -> str:
+    """Convert agentnanny Bash patterns to Codex Starlark exec policy rules.
+
+    Only Bash(...) patterns translate — non-Bash tool patterns are skipped
+    since Codex controls file operations via approval_policy, not exec rules.
+    Returns empty string when no patterns match.
+    """
+    if decision not in ("forbidden", "allow"):
+        raise ValueError(f"Invalid codex rule decision: {decision!r}")
+    justification = "blocked" if decision == "forbidden" else "allowed"
+    rules: list[str] = []
+    for pattern in patterns:
+        m = _BASH_PATTERN_RE.match(pattern)
+        if not m:
+            continue
+        for segment in m.group(1).split("|"):
+            prefix = segment.rstrip("*").rstrip()
+            if prefix:
+                rules.append(
+                    f'prefix_rule(pattern=["{prefix}"], decision="{decision}",'
+                    f' justification="{justification} by agentnanny")'
+                )
+    return "\n".join(rules)
+
+
+def _write_codex_rules(scope_id: str, content: str) -> Path:
+    """Write an exec policy rules file for the given scope."""
+    rules_dir = CODEX_HOME / "rules"
+    rules_dir.mkdir(parents=True, exist_ok=True)
+    path = rules_dir / f"agentnanny-{scope_id}.rules"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _remove_codex_rules(scope_id: str) -> bool:
+    """Remove the exec policy rules file for the given scope."""
+    path = CODEX_HOME / "rules" / f"agentnanny-{scope_id}.rules"
+    if path.exists():
+        path.unlink()
+        return True
+    return False
+
+
+def _remove_all_codex_rules() -> int:
+    """Remove all agentnanny-generated exec policy rules files."""
+    rules_dir = CODEX_HOME / "rules"
+    if not rules_dir.exists():
+        return 0
+    count = 0
+    for path in rules_dir.glob("agentnanny-*.rules"):
+        path.unlink()
+        count += 1
+    return count
+
+
+def install_codex_hooks():
+    """Register agentnanny as a notify handler in ~/.codex/config.toml."""
+    if CODEX_CONFIG_PATH.exists():
+        if HOOK_MARKER in CODEX_CONFIG_PATH.read_text(encoding="utf-8"):
+            print(f"Already installed in {CODEX_CONFIG_PATH}", file=sys.stderr)
+            raise SystemExit(1)
+
+    python_cmd = sys.executable.replace("\\", "/")
+    script_path = str(SCRIPT_PATH).replace("\\", "/")
+    notify_argv = [python_cmd, script_path, "codex-hook"]
+
+    _patch_codex_config({"notify": notify_argv})
+    print(f"Installed notify hook in {CODEX_CONFIG_PATH}")
+
+
+def uninstall_codex_hooks():
+    """Remove agentnanny notify handler from ~/.codex/config.toml."""
+    if not CODEX_CONFIG_PATH.exists():
+        print("No Codex config file found", file=sys.stderr)
+        raise SystemExit(1)
+
+    removed = _remove_codex_config_keys(["notify"])
+    if not removed:
+        print("No agentnanny hooks found in Codex config", file=sys.stderr)
+        raise SystemExit(1)
+
+    count = _remove_all_codex_rules()
+    print(f"Removed agentnanny hooks from {CODEX_CONFIG_PATH}")
+    if count:
+        print(f"Removed {count} exec policy rules file(s)")
+
+
+def handle_codex_hook():
+    """Codex notify hook handler. Receives tool execution info for audit logging."""
+    event = json.load(sys.stdin)
+    tool_name = event.get("tool_name", "")
+    tool_input = event.get("tool_input", {})
+
+    cfg = load_config()
+    detail = ""
+    if isinstance(tool_input, dict):
+        # Codex LocalShell input has a command array
+        cmd = tool_input.get("command", [])
+        if isinstance(cmd, list):
+            detail = " ".join(cmd)[:200]
+        else:
+            detail = str(cmd)[:200]
+    audit_log("codex-hook", "executed", tool_name, detail, cfg)
+
+
+def _apply_codex_session(policy: dict, cfg: dict, scope_id: str):
+    """Apply an agentnanny session policy to Codex config and rules."""
+    # Determine approval_policy from profile or groups
+    profile_name = policy.get("_profile_name")
+    approval = CODEX_APPROVAL_MAP.get(profile_name or "", "on-request")
+
+    updates: dict[str, object] = {"approval_policy": approval}
+    _patch_codex_config(updates)
+
+    # Generate exec policy rules from deny + allow patterns
+    deny_patterns = policy.get("deny", [])
+    allow_groups = policy.get("allow_groups", [])
+    allow_tools = policy.get("allow_tools", [])
+
+    allow_patterns: list[str] = list(allow_tools)
+    if allow_groups:
+        try:
+            allow_patterns.extend(resolve_groups(allow_groups, cfg))
+        except ValueError as exc:
+            print(f"Warning: {exc}", file=sys.stderr)
+
+    deny_rules = _patterns_to_codex_rules(deny_patterns, "forbidden")
+    allow_rules = _patterns_to_codex_rules(allow_patterns, "allow")
+
+    if deny_rules or allow_rules:
+        rules_parts = ["# Generated by agentnanny — do not edit manually"]
+        if deny_rules:
+            rules_parts.append(deny_rules)
+        if allow_rules:
+            rules_parts.append(allow_rules)
+        content = "\n".join(rules_parts) + "\n"
+        path = _write_codex_rules(scope_id, content)
+        print(f"# Codex rules: {path}", file=sys.stderr)
+
+    print(f"# Codex approval_policy: {approval}", file=sys.stderr)
+
+
+def _remove_codex_session(scope_id: str):
+    """Remove Codex artifacts for a session."""
+    _remove_codex_rules(scope_id)
+    _remove_codex_config_keys(["approval_policy"])
+
+
+# ---------------------------------------------------------------------------
+# Mode 1: Hook handler (Claude Code)
 # ---------------------------------------------------------------------------
 
 
@@ -575,8 +811,8 @@ def handle_hook():
     if group_names:
         try:
             allow_patterns.extend(resolve_groups(group_names, cfg))
-        except ValueError:
-            pass  # Unknown group — don't crash the hook
+        except ValueError as exc:
+            print(f"Warning: {exc}", file=sys.stderr)
 
     if matches_allow(tool_name, tool_input, allow_patterns):
         detail = _primary_input(tool_name, tool_input)[:200]
@@ -1097,6 +1333,28 @@ def show_status():
     if policies:
         print(f"Session policies: {len(policies)} active")
 
+    # Codex status
+    print()
+    print("─── Codex CLI ───")
+    if CODEX_CONFIG_PATH.exists():
+        codex_text = CODEX_CONFIG_PATH.read_text(encoding="utf-8")
+        codex_installed = HOOK_MARKER in codex_text
+        print(f"Notify hook installed: {'yes' if codex_installed else 'no'}")
+        print(f"Config: {CODEX_CONFIG_PATH}")
+        # Parse approval_policy from config
+        codex_cfg = parse_toml(codex_text)
+        ap = codex_cfg.get("approval_policy")
+        if ap:
+            print(f"Approval policy: {ap}")
+    else:
+        print("Notify hook installed: no (no config file)")
+
+    rules_dir = CODEX_HOME / "rules"
+    if rules_dir.exists():
+        rules_files = list(rules_dir.glob("agentnanny-*.rules"))
+        if rules_files:
+            print(f"Exec policy rules: {len(rules_files)} file(s)")
+
 
 def show_log(
     lines_count: int = 50,
@@ -1179,12 +1437,10 @@ def _parse_ttl(ttl_str: str) -> int:
     return int(ttl_str)
 
 
-def cmd_activate(profile: str | None, groups: str | None, tools: str | None,
-                 deny: str | None, ttl: str | None):
-    """Create a session policy and print the env export command."""
-    cfg = load_config()
-
-    # Start from profile defaults if specified
+def _build_policy(profile: str | None, groups: str | None, tools: str | None,
+                  deny: str | None, ttl: str | None,
+                  cfg: dict) -> tuple[dict, str]:
+    """Build a session policy dict from CLI args. Returns (policy, scope_id)."""
     if profile:
         p = resolve_profile(profile, cfg)
         base_groups = p["groups"]
@@ -1195,17 +1451,14 @@ def cmd_activate(profile: str | None, groups: str | None, tools: str | None,
         base_deny = []
         base_ttl = "0"
 
-    # CLI flags merge on top of profile
     group_names = base_groups + ([g.strip() for g in groups.split(",")] if groups else [])
     tool_names = [t.strip() for t in tools.split(",")] if tools else []
     deny_patterns = base_deny + ([d.strip() for d in deny.split(",")] if deny else [])
     ttl_seconds = _parse_ttl(ttl if ttl is not None else base_ttl)
 
-    # Validate group names
     if group_names:
         resolve_groups(group_names, cfg)
 
-    # Validate deny pattern syntax
     for pat in deny_patterns:
         m_pat = re.match(r'^(\w+)\((.+)\)$', pat)
         if m_pat:
@@ -1214,7 +1467,6 @@ def cmd_activate(profile: str | None, groups: str | None, tools: str | None,
             except re.error as exc:
                 raise ValueError(f"Invalid deny pattern {pat!r}: {exc}") from exc
         else:
-            # Plain pattern is used as regex in fullmatch — validate it
             try:
                 re.compile(pat)
             except re.error as exc:
@@ -1229,6 +1481,22 @@ def cmd_activate(profile: str | None, groups: str | None, tools: str | None,
         "allow_tools": tool_names,
         "deny": deny_patterns,
     }
+    if profile:
+        policy["_profile_name"] = profile
+    return policy, scope_id
+
+
+def cmd_activate(profile: str | None, groups: str | None, tools: str | None,
+                 deny: str | None, ttl: str | None, target: str = "claude"):
+    """Create a session policy and print the env export command."""
+    cfg = load_config()
+    policy, scope_id = _build_policy(profile, groups, tools, deny, ttl, cfg)
+
+    group_names = policy["allow_groups"]
+    tool_names = policy["allow_tools"]
+    deny_patterns = policy["deny"]
+    ttl_seconds = policy["ttl_seconds"]
+
     path = save_session_policy(policy)
     print(f"export AGENTNANNY_SCOPE={scope_id}")
     print(f"# Policy: {path}", file=sys.stderr)
@@ -1240,6 +1508,9 @@ def cmd_activate(profile: str | None, groups: str | None, tools: str | None,
         print(f"# Deny: {', '.join(deny_patterns)}", file=sys.stderr)
     if ttl_seconds:
         print(f"# TTL: {ttl_seconds}s", file=sys.stderr)
+
+    if target == "codex":
+        _apply_codex_session(policy, cfg, scope_id)
 
 
 def cmd_extend(scope_id: str | None, groups: str | None, tools: str | None,
@@ -1302,7 +1573,7 @@ def cmd_extend(scope_id: str | None, groups: str | None, tools: str | None,
     print(f"# Deny: {', '.join(existing_deny)}", file=sys.stderr)
 
 
-def cmd_deactivate(scope_id: str | None):
+def cmd_deactivate(scope_id: str | None, target: str = "claude"):
     """Remove a session policy."""
     scope_id = scope_id or os.environ.get("AGENTNANNY_SCOPE")
     if not scope_id:
@@ -1314,18 +1585,21 @@ def cmd_deactivate(scope_id: str | None):
     if delete_session_policy(scope_id):
         print(f"unset AGENTNANNY_SCOPE")
         print(f"# Removed session {scope_id}", file=sys.stderr)
+        if target == "codex":
+            _remove_codex_session(scope_id)
+            print("# Removed Codex exec policy rules", file=sys.stderr)
     else:
         print(f"No session policy found for {scope_id}", file=sys.stderr)
         raise SystemExit(1)
 
 
 def cmd_run(profile: str | None, groups: str | None, tools: str | None,
-            deny: str | None, ttl: str | None, command_args: list[str]):
+            deny: str | None, ttl: str | None, command_args: list[str],
+            target: str = "claude"):
     """Run a command with session-scoped permissions."""
     if not command_args:
         print("No command specified", file=sys.stderr)
         raise SystemExit(1)
-    # Strip leading -- if present
     if command_args and command_args[0] == "--":
         command_args = command_args[1:]
     if not command_args:
@@ -1333,46 +1607,22 @@ def cmd_run(profile: str | None, groups: str | None, tools: str | None,
         raise SystemExit(1)
 
     cfg = load_config()
-
-    # Start from profile defaults if specified
-    if profile:
-        p = resolve_profile(profile, cfg)
-        base_groups = p["groups"]
-        base_deny = p["deny"]
-        base_ttl = p["ttl"]
-    else:
-        base_groups = []
-        base_deny = []
-        base_ttl = "0"
-
-    # CLI flags merge on top of profile
-    group_names = base_groups + ([g.strip() for g in groups.split(",")] if groups else [])
-    tool_names = [t.strip() for t in tools.split(",")] if tools else []
-    deny_patterns = base_deny + ([d.strip() for d in deny.split(",")] if deny else [])
-    ttl_seconds = _parse_ttl(ttl if ttl is not None else base_ttl)
-
-    if group_names:
-        resolve_groups(group_names, cfg)
-
-    scope_id = generate_scope_id()
-    policy = {
-        "scope_id": scope_id,
-        "created": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-        "ttl_seconds": ttl_seconds,
-        "allow_groups": group_names,
-        "allow_tools": tool_names,
-        "deny": deny_patterns,
-    }
+    policy, scope_id = _build_policy(profile, groups, tools, deny, ttl, cfg)
     save_session_policy(policy)
 
     env = os.environ.copy()
     env["AGENTNANNY_SCOPE"] = scope_id
+
+    if target == "codex":
+        _apply_codex_session(policy, cfg, scope_id)
 
     try:
         result = subprocess.run(command_args, env=env)
         raise SystemExit(result.returncode)
     finally:
         delete_session_policy(scope_id)
+        if target == "codex":
+            _remove_codex_session(scope_id)
 
 
 PROJECT_CONFIG_TEMPLATE = """\
@@ -1571,8 +1821,8 @@ def evaluate_policy(
     if group_names:
         try:
             allow_patterns.extend(resolve_groups(group_names, cfg))
-        except ValueError:
-            pass
+        except ValueError as exc:
+            return ("passthrough", f"group resolution failed: {exc}")
 
     if matches_allow(tool_name, tool_input, allow_patterns):
         return ("allow", f"{tool_name} allowed by session policy (scope {scope_id})")
@@ -1597,14 +1847,20 @@ def cmd_test_policy(tool_name: str, tool_input_json: str, scope: str | None):
 def main():
     parser = argparse.ArgumentParser(
         prog="agentnanny",
-        description="Auto-approve Claude Code permission prompts via hooks + tmux daemon.",
+        description="Granular permission manager for Claude Code and Codex CLI.",
     )
     sub = parser.add_subparsers(dest="command")
 
     sub.add_parser("hook", help="Hook handler (called by Claude Code, not user)")
     sub.add_parser("post-hook", help="PostToolUse hook handler (called by Claude Code, not user)")
-    sub.add_parser("install", help="Register hooks in ~/.claude/settings.json")
-    sub.add_parser("uninstall", help="Remove hooks from ~/.claude/settings.json")
+    sub.add_parser("codex-hook", help="Notify handler (called by Codex CLI, not user)")
+
+    p_install = sub.add_parser("install", help="Register hooks in agent config")
+    p_install.add_argument("--target", choices=TARGETS, default="claude",
+                           help="Target agent (default: claude)")
+    p_uninstall = sub.add_parser("uninstall", help="Remove hooks from agent config")
+    p_uninstall.add_argument("--target", choices=TARGETS, default="claude",
+                             help="Target agent (default: claude)")
 
     p_trust = sub.add_parser("trust", help="Pre-trust a directory")
     p_trust.add_argument("directory", nargs="?", default=".", help="Directory to trust (default: .)")
@@ -1627,9 +1883,13 @@ def main():
     p_activate.add_argument("--tools", "-t", default=None, help="Comma-separated tool names")
     p_activate.add_argument("--deny", "-d", default=None, help="Comma-separated deny patterns")
     p_activate.add_argument("--ttl", default=None, help="TTL (e.g. 8h, 30m, 3600)")
+    p_activate.add_argument("--target", choices=TARGETS, default="claude",
+                            help="Target agent (default: claude)")
 
     p_deactivate = sub.add_parser("deactivate", help="Remove a session policy")
     p_deactivate.add_argument("scope_id", nargs="?", default=None, help="Scope ID (default: from AGENTNANNY_SCOPE)")
+    p_deactivate.add_argument("--target", choices=TARGETS, default="claude",
+                              help="Target agent (default: claude)")
 
     p_extend = sub.add_parser("extend", help="Add groups, tools, or deny patterns to an existing session")
     p_extend.add_argument("scope_id", nargs="?", default=None, help="Scope ID (default: from AGENTNANNY_SCOPE)")
@@ -1643,6 +1903,8 @@ def main():
     p_run.add_argument("--tools", "-t", default=None, help="Comma-separated tool names")
     p_run.add_argument("--deny", "-d", default=None, help="Comma-separated deny patterns")
     p_run.add_argument("--ttl", default=None, help="TTL (e.g. 8h, 30m, 3600)")
+    p_run.add_argument("--target", choices=TARGETS, default="claude",
+                        help="Target agent (default: claude)")
     p_run.add_argument("command_args", nargs=argparse.REMAINDER, help="Command to run (after --)")
 
     sub.add_parser("profiles", help="List available profiles")
@@ -1664,10 +1926,18 @@ def main():
         handle_hook()
     elif args.command == "post-hook":
         handle_post_hook()
+    elif args.command == "codex-hook":
+        handle_codex_hook()
     elif args.command == "install":
-        install_hooks()
+        if args.target == "codex":
+            install_codex_hooks()
+        else:
+            install_hooks()
     elif args.command == "uninstall":
-        uninstall_hooks()
+        if args.target == "codex":
+            uninstall_codex_hooks()
+        else:
+            uninstall_hooks()
     elif args.command == "trust":
         trust_directory(args.directory)
     elif args.command == "watch":
@@ -1686,13 +1956,13 @@ def main():
             filter_action=args.action,
         )
     elif args.command == "activate":
-        cmd_activate(args.profile, args.groups, args.tools, args.deny, args.ttl)
+        cmd_activate(args.profile, args.groups, args.tools, args.deny, args.ttl, args.target)
     elif args.command == "deactivate":
-        cmd_deactivate(args.scope_id)
+        cmd_deactivate(args.scope_id, args.target)
     elif args.command == "extend":
         cmd_extend(args.scope_id, args.groups, args.tools, args.deny)
     elif args.command == "run":
-        cmd_run(args.profile, args.groups, args.tools, args.deny, args.ttl, args.command_args)
+        cmd_run(args.profile, args.groups, args.tools, args.deny, args.ttl, args.command_args, args.target)
     elif args.command == "profiles":
         cmd_list_profiles()
     elif args.command == "sessions":

--- a/test_agentnanny.py
+++ b/test_agentnanny.py
@@ -2733,3 +2733,591 @@ class TestPostToolUseHook:
         assert len(post) == 1
         assert "agentnanny" in post[0]["hooks"][0]["command"]
         assert "post-hook" in post[0]["hooks"][0]["command"]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Codex CLI integration
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestSerializeTomlValue:
+    def test_string(self):
+        assert agentnanny._serialize_toml_value("hello") == '"hello"'
+
+    def test_bool_true(self):
+        assert agentnanny._serialize_toml_value(True) == "true"
+
+    def test_bool_false(self):
+        assert agentnanny._serialize_toml_value(False) == "false"
+
+    def test_int(self):
+        assert agentnanny._serialize_toml_value(42) == "42"
+
+    def test_list_of_strings(self):
+        result = agentnanny._serialize_toml_value(["a", "b", "c"])
+        assert result == '["a", "b", "c"]'
+
+    def test_empty_list(self):
+        assert agentnanny._serialize_toml_value([]) == "[]"
+
+    def test_unsupported_type(self):
+        with pytest.raises(TypeError):
+            agentnanny._serialize_toml_value({"key": "val"})
+
+
+class TestPatchCodexConfig:
+    def test_creates_config_file(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        config_path = codex_home / "config.toml"
+        with patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            agentnanny._patch_codex_config({"approval_policy": "on-request"})
+
+        assert config_path.exists()
+        content = config_path.read_text(encoding="utf-8")
+        assert 'approval_policy = "on-request"' in content
+
+    def test_preserves_existing_keys(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        codex_home.mkdir()
+        config_path = codex_home / "config.toml"
+        config_path.write_text('model = "o3"\n', encoding="utf-8")
+
+        with patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            agentnanny._patch_codex_config({"approval_policy": "never"})
+
+        content = config_path.read_text(encoding="utf-8")
+        assert 'model = "o3"' in content
+        assert 'approval_policy = "never"' in content
+
+    def test_replaces_existing_key(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        codex_home.mkdir()
+        config_path = codex_home / "config.toml"
+        config_path.write_text('approval_policy = "on-request"\n', encoding="utf-8")
+
+        with patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            agentnanny._patch_codex_config({"approval_policy": "never"})
+
+        content = config_path.read_text(encoding="utf-8")
+        assert 'approval_policy = "never"' in content
+        assert "on-request" not in content
+
+    def test_preserves_comments(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        codex_home.mkdir()
+        config_path = codex_home / "config.toml"
+        config_path.write_text('# My config\nmodel = "o3"\n', encoding="utf-8")
+
+        with patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            agentnanny._patch_codex_config({"notify": ["python3", "agentnanny.py"]})
+
+        content = config_path.read_text(encoding="utf-8")
+        assert "# My config" in content
+        assert 'notify = ["python3", "agentnanny.py"]' in content
+
+    def test_writes_list_value(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        config_path = codex_home / "config.toml"
+        with patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            agentnanny._patch_codex_config({"notify": ["cmd", "arg1", "arg2"]})
+
+        content = config_path.read_text(encoding="utf-8")
+        assert 'notify = ["cmd", "arg1", "arg2"]' in content
+
+
+class TestRemoveCodexConfigKeys:
+    def test_removes_key(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        codex_home.mkdir()
+        config_path = codex_home / "config.toml"
+        config_path.write_text('model = "o3"\napproval_policy = "never"\n', encoding="utf-8")
+
+        with patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            result = agentnanny._remove_codex_config_keys(["approval_policy"])
+
+        assert result is True
+        content = config_path.read_text(encoding="utf-8")
+        assert "approval_policy" not in content
+        assert 'model = "o3"' in content
+
+    def test_no_file_returns_false(self, tmp_path):
+        config_path = tmp_path / "nonexistent.toml"
+        with patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            result = agentnanny._remove_codex_config_keys(["approval_policy"])
+        assert result is False
+
+    def test_key_not_present(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        codex_home.mkdir()
+        config_path = codex_home / "config.toml"
+        config_path.write_text('model = "o3"\n', encoding="utf-8")
+
+        with patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            result = agentnanny._remove_codex_config_keys(["approval_policy"])
+        assert result is False
+
+
+class TestPatternsToCodexRules:
+    def test_deny_bash_pattern(self):
+        rules = agentnanny._patterns_to_codex_rules(["Bash(rm -rf /*)"], "forbidden")
+        assert 'pattern=["rm -rf /"]' in rules
+        assert 'decision="forbidden"' in rules
+        assert 'justification="blocked by agentnanny"' in rules
+
+    def test_deny_alternation_pattern(self):
+        rules = agentnanny._patterns_to_codex_rules(["Bash(curl*|wget*)"], "forbidden")
+        assert 'pattern=["curl"]' in rules
+        assert 'pattern=["wget"]' in rules
+
+    def test_non_bash_skipped(self):
+        rules = agentnanny._patterns_to_codex_rules(["WebFetch", "Write"], "forbidden")
+        assert rules.strip() == ""
+
+    def test_deny_git_push_force(self):
+        rules = agentnanny._patterns_to_codex_rules(["Bash(git push --force*)"], "forbidden")
+        assert 'pattern=["git push --force"]' in rules
+        assert 'decision="forbidden"' in rules
+
+    def test_deny_mixed_patterns(self):
+        rules = agentnanny._patterns_to_codex_rules([
+            "Bash(rm -rf /*)",
+            "WebFetch",
+            "Bash(DROP TABLE*)",
+        ], "forbidden")
+        assert 'pattern=["rm -rf /"]' in rules
+        assert 'pattern=["DROP TABLE"]' in rules
+        assert "WebFetch" not in rules
+
+    def test_allow_bash_pattern(self):
+        rules = agentnanny._patterns_to_codex_rules(["Bash(ls*)"], "allow")
+        assert 'pattern=["ls"]' in rules
+        assert 'decision="allow"' in rules
+        assert 'justification="allowed by agentnanny"' in rules
+
+    def test_allow_git_commands(self):
+        rules = agentnanny._patterns_to_codex_rules([
+            "Bash(git log*)", "Bash(git diff*)", "Bash(git show*)",
+        ], "allow")
+        assert 'pattern=["git log"]' in rules
+        assert 'pattern=["git diff"]' in rules
+        assert 'pattern=["git show"]' in rules
+
+    def test_allow_non_bash_skipped(self):
+        rules = agentnanny._patterns_to_codex_rules(["Read", "Glob", "Grep"], "allow")
+        assert rules.strip() == ""
+
+    def test_allow_alternation(self):
+        rules = agentnanny._patterns_to_codex_rules(["Bash(cat*|head*)"], "allow")
+        assert 'pattern=["cat"]' in rules
+        assert 'pattern=["head"]' in rules
+
+
+class TestWriteRemoveCodexRules:
+    def test_write_creates_file(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        with patch.object(agentnanny, "CODEX_HOME", codex_home):
+            path = agentnanny._write_codex_rules("abc12345", "# test rules\n")
+
+        assert path.exists()
+        assert path.name == "agentnanny-abc12345.rules"
+        assert path.read_text(encoding="utf-8") == "# test rules\n"
+
+    def test_remove_deletes_file(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        rules_dir = codex_home / "rules"
+        rules_dir.mkdir(parents=True)
+        rules_file = rules_dir / "agentnanny-abc12345.rules"
+        rules_file.write_text("# test\n", encoding="utf-8")
+
+        with patch.object(agentnanny, "CODEX_HOME", codex_home):
+            result = agentnanny._remove_codex_rules("abc12345")
+
+        assert result is True
+        assert not rules_file.exists()
+
+    def test_remove_nonexistent(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        with patch.object(agentnanny, "CODEX_HOME", codex_home):
+            result = agentnanny._remove_codex_rules("abc12345")
+        assert result is False
+
+    def test_remove_all(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        rules_dir = codex_home / "rules"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "agentnanny-abc12345.rules").write_text("# 1\n")
+        (rules_dir / "agentnanny-def67890.rules").write_text("# 2\n")
+        (rules_dir / "other.rules").write_text("# 3\n")
+
+        with patch.object(agentnanny, "CODEX_HOME", codex_home):
+            count = agentnanny._remove_all_codex_rules()
+
+        assert count == 2
+        assert (rules_dir / "other.rules").exists()
+
+
+class TestInstallUninstallCodex:
+    def test_install_creates_notify(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        config_path = codex_home / "config.toml"
+
+        with patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            agentnanny.install_codex_hooks()
+
+        content = config_path.read_text(encoding="utf-8")
+        assert "agentnanny" in content
+        assert "codex-hook" in content
+        assert content.startswith("notify = [")
+
+    def test_install_idempotent(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        config_path = codex_home / "config.toml"
+
+        with patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            agentnanny.install_codex_hooks()
+            with pytest.raises(SystemExit):
+                agentnanny.install_codex_hooks()
+
+    def test_install_preserves_existing(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        codex_home.mkdir()
+        config_path = codex_home / "config.toml"
+        config_path.write_text('model = "o3"\n', encoding="utf-8")
+
+        with patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            agentnanny.install_codex_hooks()
+
+        content = config_path.read_text(encoding="utf-8")
+        assert 'model = "o3"' in content
+        assert "agentnanny" in content
+
+    def test_uninstall_removes_notify(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        config_path = codex_home / "config.toml"
+
+        with patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            agentnanny.install_codex_hooks()
+            agentnanny.uninstall_codex_hooks()
+
+        content = config_path.read_text(encoding="utf-8")
+        assert "notify" not in content
+
+    def test_uninstall_no_config_exits(self, tmp_path):
+        config_path = tmp_path / "nonexistent.toml"
+        with patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            with pytest.raises(SystemExit):
+                agentnanny.uninstall_codex_hooks()
+
+    def test_uninstall_removes_rules_files(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        config_path = codex_home / "config.toml"
+        rules_dir = codex_home / "rules"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "agentnanny-abc12345.rules").write_text("# test\n")
+
+        with patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            agentnanny.install_codex_hooks()
+            agentnanny.uninstall_codex_hooks()
+
+        assert not (rules_dir / "agentnanny-abc12345.rules").exists()
+
+
+class TestCodexHook:
+    def test_logs_shell_command(self, tmp_path):
+        event = {
+            "tool_name": "shell_command",
+            "tool_input": {"command": ["ls", "-la", "/tmp"]},
+        }
+        stdin = StringIO(json.dumps(event))
+        cfg = {"hooks": {}, "logging": {"audit_log": os.devnull, "level": "all"}}
+
+        with patch.object(sys, "stdin", stdin), \
+             patch.object(agentnanny, "load_config", return_value=cfg), \
+             patch.object(agentnanny, "audit_log") as mock_log:
+            agentnanny.handle_codex_hook()
+
+        mock_log.assert_called_once()
+        assert mock_log.call_args[0][0] == "codex-hook"
+        assert mock_log.call_args[0][1] == "executed"
+        assert mock_log.call_args[0][2] == "shell_command"
+        assert "ls -la /tmp" in mock_log.call_args[0][3]
+
+    def test_handles_string_command(self, tmp_path):
+        event = {
+            "tool_name": "apply_patch",
+            "tool_input": {"command": "patch content"},
+        }
+        stdin = StringIO(json.dumps(event))
+        cfg = {"hooks": {}, "logging": {"audit_log": os.devnull, "level": "all"}}
+
+        with patch.object(sys, "stdin", stdin), \
+             patch.object(agentnanny, "load_config", return_value=cfg), \
+             patch.object(agentnanny, "audit_log") as mock_log:
+            agentnanny.handle_codex_hook()
+
+        assert mock_log.call_args[0][3] == "patch content"
+
+
+class TestApplyRemoveCodexSession:
+    def _make_cfg(self):
+        return {
+            "hooks": {},
+            "groups": dict(agentnanny.BUILTIN_GROUPS),
+            "profiles": {k: dict(v) for k, v in agentnanny.BUILTIN_PROFILES.items()},
+            "logging": {"audit_log": os.devnull},
+        }
+
+    def test_apply_sets_approval_policy(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        config_path = codex_home / "config.toml"
+        cfg = self._make_cfg()
+        policy = {
+            "_profile_name": "safe-dev",
+            "deny": [],
+            "allow_groups": ["filesystem", "safe-shell"],
+            "allow_tools": [],
+        }
+
+        with patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            agentnanny._apply_codex_session(policy, cfg, "abc12345")
+
+        content = config_path.read_text(encoding="utf-8")
+        assert 'approval_policy = "unless-trusted"' in content
+
+    def test_apply_generates_deny_rules(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        config_path = codex_home / "config.toml"
+        cfg = self._make_cfg()
+        policy = {
+            "_profile_name": "full-dev",
+            "deny": ["Bash(rm -rf /*)", "Bash(git push --force*)"],
+            "allow_groups": ["filesystem", "shell"],
+            "allow_tools": [],
+        }
+
+        with patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            agentnanny._apply_codex_session(policy, cfg, "abc12345")
+
+        rules_path = codex_home / "rules" / "agentnanny-abc12345.rules"
+        assert rules_path.exists()
+        content = rules_path.read_text(encoding="utf-8")
+        assert 'pattern=["rm -rf /"]' in content
+        assert 'pattern=["git push --force"]' in content
+        assert 'decision="forbidden"' in content
+
+    def test_apply_generates_allow_rules(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        config_path = codex_home / "config.toml"
+        cfg = self._make_cfg()
+        policy = {
+            "_profile_name": "reviewer",
+            "deny": [],
+            "allow_groups": ["review-shell"],
+            "allow_tools": [],
+        }
+
+        with patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            agentnanny._apply_codex_session(policy, cfg, "abc12345")
+
+        rules_path = codex_home / "rules" / "agentnanny-abc12345.rules"
+        assert rules_path.exists()
+        content = rules_path.read_text(encoding="utf-8")
+        assert 'pattern=["git log"]' in content
+        assert 'decision="allow"' in content
+
+    def test_remove_cleans_up(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        codex_home.mkdir()
+        config_path = codex_home / "config.toml"
+        config_path.write_text('approval_policy = "never"\n', encoding="utf-8")
+        rules_dir = codex_home / "rules"
+        rules_dir.mkdir()
+        (rules_dir / "agentnanny-abc12345.rules").write_text("# test\n")
+
+        with patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            agentnanny._remove_codex_session("abc12345")
+
+        assert not (rules_dir / "agentnanny-abc12345.rules").exists()
+        content = config_path.read_text(encoding="utf-8")
+        assert "approval_policy" not in content
+
+    def test_unknown_profile_defaults_on_request(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        config_path = codex_home / "config.toml"
+        cfg = self._make_cfg()
+        policy = {
+            "deny": [],
+            "allow_groups": [],
+            "allow_tools": ["Bash"],
+        }
+
+        with patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            agentnanny._apply_codex_session(policy, cfg, "abc12345")
+
+        content = config_path.read_text(encoding="utf-8")
+        assert 'approval_policy = "on-request"' in content
+
+
+class TestActivateDeactivateCodex:
+    def test_activate_codex_target(self, tmp_path, capsys):
+        codex_home = tmp_path / ".codex"
+        config_path = codex_home / "config.toml"
+        cfg = {
+            "hooks": {},
+            "groups": dict(agentnanny.BUILTIN_GROUPS),
+            "profiles": {k: dict(v) for k, v in agentnanny.BUILTIN_PROFILES.items()},
+            "logging": {"audit_log": os.devnull},
+        }
+        with patch.object(agentnanny, "SESSION_DIR", tmp_path / "sessions"), \
+             patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path), \
+             patch.object(agentnanny, "load_config", return_value=cfg):
+            agentnanny.cmd_activate("safe-dev", None, None, None, "8h", target="codex")
+
+        out = capsys.readouterr().out
+        assert "export AGENTNANNY_SCOPE=" in out
+        assert config_path.exists()
+        content = config_path.read_text(encoding="utf-8")
+        assert "unless-trusted" in content
+
+    def test_deactivate_codex_target(self, tmp_path, capsys):
+        codex_home = tmp_path / ".codex"
+        codex_home.mkdir()
+        config_path = codex_home / "config.toml"
+        config_path.write_text('approval_policy = "never"\n', encoding="utf-8")
+        rules_dir = codex_home / "rules"
+        rules_dir.mkdir()
+        (rules_dir / "agentnanny-dea01234.rules").write_text("# test\n")
+
+        with patch.object(agentnanny, "SESSION_DIR", tmp_path / "sessions"), \
+             patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            (tmp_path / "sessions").mkdir()
+            agentnanny.save_session_policy({
+                "scope_id": "dea01234",
+                "created": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                "ttl_seconds": 0,
+                "allow_groups": [],
+                "allow_tools": [],
+                "deny": [],
+            })
+            agentnanny.cmd_deactivate("dea01234", target="codex")
+
+        out = capsys.readouterr().out
+        assert "unset AGENTNANNY_SCOPE" in out
+        assert not (rules_dir / "agentnanny-dea01234.rules").exists()
+
+
+class TestCodexApprovalMap:
+    def test_all_builtin_profiles_mapped(self):
+        for name in agentnanny.BUILTIN_PROFILES:
+            assert name in agentnanny.CODEX_APPROVAL_MAP, \
+                f"Profile {name!r} missing from CODEX_APPROVAL_MAP"
+
+    def test_values_are_valid_codex_policies(self):
+        valid = {"never", "on-failure", "on-request", "unless-trusted"}
+        for name, policy in agentnanny.CODEX_APPROVAL_MAP.items():
+            assert policy in valid, f"{name} maps to invalid policy {policy!r}"
+
+
+class TestBuildPolicy:
+    def test_includes_profile_name(self):
+        cfg = {
+            "hooks": {},
+            "groups": dict(agentnanny.BUILTIN_GROUPS),
+            "profiles": {k: dict(v) for k, v in agentnanny.BUILTIN_PROFILES.items()},
+        }
+        policy, scope_id = agentnanny._build_policy("safe-dev", None, None, None, "1h", cfg)
+        assert policy["_profile_name"] == "safe-dev"
+        assert policy["ttl_seconds"] == 3600
+
+    def test_no_profile_no_key(self):
+        cfg = {"hooks": {}, "groups": {}, "profiles": {}}
+        policy, _ = agentnanny._build_policy(None, None, "Bash", None, "0", cfg)
+        assert "_profile_name" not in policy
+
+    def test_merges_groups_and_tools(self):
+        cfg = {
+            "hooks": {},
+            "groups": {"shell": ["Bash"], "read-only": ["Read", "Glob", "Grep"]},
+            "profiles": {},
+        }
+        policy, _ = agentnanny._build_policy(None, "shell,read-only", "Write", None, "0", cfg)
+        assert policy["allow_groups"] == ["shell", "read-only"]
+        assert policy["allow_tools"] == ["Write"]
+
+
+class TestCodexStatus:
+    def test_shows_codex_section(self, tmp_path, capsys):
+        codex_home = tmp_path / ".codex"
+        codex_home.mkdir()
+        config_path = codex_home / "config.toml"
+        config_path.write_text(
+            'notify = ["python3", "agentnanny.py", "codex-hook"]\n'
+            'approval_policy = "never"\n',
+            encoding="utf-8",
+        )
+
+        with patch.object(agentnanny, "SETTINGS_PATH", tmp_path / "nonexistent.json"), \
+             patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path), \
+             patch.object(agentnanny, "SESSION_DIR", tmp_path / "sessions"), \
+             patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AGENTNANNY_SCOPE", None)
+            agentnanny.show_status()
+
+        err = capsys.readouterr().out
+        assert "Codex CLI" in err
+        assert "Notify hook installed: yes" in err
+        assert "Approval policy: never" in err
+
+    def test_shows_codex_not_installed(self, tmp_path, capsys):
+        codex_home = tmp_path / ".codex"
+        config_path = codex_home / "nonexistent.toml"
+
+        with patch.object(agentnanny, "SETTINGS_PATH", tmp_path / "nonexistent.json"), \
+             patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path), \
+             patch.object(agentnanny, "SESSION_DIR", tmp_path / "sessions"), \
+             patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AGENTNANNY_SCOPE", None)
+            agentnanny.show_status()
+
+        err = capsys.readouterr().out
+        assert "Notify hook installed: no" in err
+
+    def test_shows_rules_count(self, tmp_path, capsys):
+        codex_home = tmp_path / ".codex"
+        codex_home.mkdir()
+        config_path = codex_home / "config.toml"
+        config_path.write_text('model = "o3"\n', encoding="utf-8")
+        rules_dir = codex_home / "rules"
+        rules_dir.mkdir()
+        (rules_dir / "agentnanny-abc12345.rules").write_text("# 1\n")
+        (rules_dir / "agentnanny-def67890.rules").write_text("# 2\n")
+
+        with patch.object(agentnanny, "SETTINGS_PATH", tmp_path / "nonexistent.json"), \
+             patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path), \
+             patch.object(agentnanny, "SESSION_DIR", tmp_path / "sessions"), \
+             patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AGENTNANNY_SCOPE", None)
+            agentnanny.show_status()
+
+        err = capsys.readouterr().out
+        assert "Exec policy rules: 2 file(s)" in err


### PR DESCRIPTION
## Summary

Extends agentnanny to support OpenAI's Codex CLI alongside Claude Code, using Codex's existing extension points — no Codex binary modifications required.

### What's included

- **Codex exec policy rules**: Translate agentnanny Bash patterns to Starlark `prefix_rule` directives in `~/.codex/rules/`
- **Config management**: Patch `~/.codex/config.toml` with `approval_policy` mapped from agentnanny profiles, preserving existing content
- **Notify hook**: `codex-hook` subcommand for post-execution audit logging
- **CLI integration**: `--target codex` flag on `activate`, `deactivate`, `run`, `install`, and `uninstall` subcommands
- **Status display**: Codex CLI section in `agentnanny status` output

### Code quality improvements

- Extract `_build_policy` from `cmd_activate`/`cmd_run` (eliminates ~60 lines of duplication)
- Consolidate `_deny_to_codex_rules`/`_allow_to_codex_rules` into `_patterns_to_codex_rules` with input validation
- Surface `resolve_groups` failures as warnings instead of silently swallowing `ValueError`

### Profile → Codex approval_policy mapping

| Profile | approval_policy |
|---------|----------------|
| reviewer | unless-trusted |
| safe-dev | unless-trusted |
| full-dev | on-failure |
| overnight | on-failure |
| ci-runner | never |

## Test plan

- [x] 292 tests pass (`uv run pytest`)
- [x] 51 new tests across 13 test classes covering all Codex integration functions
- [x] Dry-run activate/deactivate verified against real `~/.codex/config.toml`
- [x] Generated rules match existing Codex Starlark format
- [x] Config patching preserves existing content (projects, MCP servers)
- [ ] End-to-end: activate with `--target codex` → run Codex interactive → verify policy enforcement