### PR TITLE
Fix Codex no-prompt sessions and harden hook installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,11 @@ Profile-to-Codex approval policy mapping:
 |---|---|
 | reviewer | unless-trusted |
 | safe-dev | unless-trusted |
-| full-dev | on-failure |
-| overnight | on-failure |
+| full-dev | never |
+| overnight | never |
 | ci-runner | never |
 
-Deny/allow `Bash(...)` patterns translate to Codex Starlark `prefix_rule()` directives in `~/.codex/rules/`. Non-Bash patterns are skipped (Codex controls file operations via `approval_policy`).
+Deny/allow `Bash(...)` patterns translate to Codex Starlark `prefix_rule()` directives in `~/.codex/rules/`. Non-Bash patterns are skipped because Codex governs native tool execution through `approval_policy`. When activating a Codex-targeted session, agentnanny also suspends explicit MCP tool `approval_mode` overrides in `~/.codex/config.toml` for the lifetime of the session so those tools fall back to the active top-level policy, then restores the prior MCP settings on deactivate.
 
 ### Requirements
 

--- a/agentnanny.py
+++ b/agentnanny.py
@@ -43,8 +43,8 @@ TARGETS = ("claude", "codex")
 CODEX_APPROVAL_MAP: dict[str, str] = {
     "reviewer": "unless-trusted",
     "safe-dev": "unless-trusted",
-    "full-dev": "on-failure",
-    "overnight": "on-failure",
+    "full-dev": "never",
+    "overnight": "never",
     "ci-runner": "never",
 }
 
@@ -585,6 +585,101 @@ def _remove_codex_config_keys(keys: list[str]) -> bool:
     return removed
 
 
+def _get_codex_top_level_value(key: str) -> object | None:
+    """Return the parsed top-level config value for key, or None if missing."""
+    if not CODEX_CONFIG_PATH.exists():
+        return None
+    lines = CODEX_CONFIG_PATH.read_text(encoding="utf-8").splitlines()
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("["):
+            break
+        if stripped.startswith(f"{key} ") or stripped.startswith(f"{key}="):
+            match = re.match(rf"^{re.escape(key)}\s*=\s*(.+)$", stripped)
+            if match:
+                return _parse_toml_value(match.group(1).strip())
+    return None
+
+
+def _suspend_codex_mcp_approval_prompts() -> dict[str, str]:
+    """Remove MCP tool approval overrides so Codex falls back to approval_policy."""
+    if not CODEX_CONFIG_PATH.exists():
+        return {}
+
+    lines = CODEX_CONFIG_PATH.read_text(encoding="utf-8").splitlines()
+    current_section: str | None = None
+    suspended: dict[str, str] = {}
+    new_lines: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            current_section = stripped[1:-1]
+            new_lines.append(line)
+            continue
+
+        if (
+            current_section is not None
+            and current_section.startswith("mcp_servers.")
+            and ".tools." in current_section
+            and (stripped.startswith("approval_mode ") or stripped.startswith("approval_mode="))
+        ):
+            match = re.match(r"^approval_mode\s*=\s*(.+)$", stripped)
+            if match:
+                suspended[current_section] = match.group(1).strip()
+                continue
+
+        new_lines.append(line)
+
+    if suspended:
+        CODEX_CONFIG_PATH.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+    return suspended
+
+
+def _restore_codex_mcp_approval_prompts(saved_modes: dict[str, str]) -> None:
+    """Restore MCP tool approval overrides previously removed for a session."""
+    if not saved_modes:
+        return
+
+    lines: list[str] = []
+    if CODEX_CONFIG_PATH.exists():
+        lines = CODEX_CONFIG_PATH.read_text(encoding="utf-8").splitlines()
+
+    current_section: str | None = None
+    seen_sections: set[str] = set()
+    new_lines: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            current_section = stripped[1:-1]
+            seen_sections.add(current_section)
+            new_lines.append(line)
+            if current_section in saved_modes:
+                new_lines.append(f"approval_mode = {saved_modes[current_section]}")
+            continue
+
+        if (
+            current_section in saved_modes
+            and (stripped.startswith("approval_mode ") or stripped.startswith("approval_mode="))
+        ):
+            continue
+
+        new_lines.append(line)
+
+    missing_sections = [section for section in saved_modes if section not in seen_sections]
+    if missing_sections and new_lines and new_lines[-1].strip():
+        new_lines.append("")
+    for section in missing_sections:
+        new_lines.append(f"[{section}]")
+        new_lines.append(f"approval_mode = {saved_modes[section]}")
+        new_lines.append("")
+
+    while new_lines and not new_lines[-1].strip():
+        new_lines.pop()
+    CODEX_CONFIG_PATH.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+
+
 _BASH_PATTERN_RE = re.compile(r'^Bash\((.+)\)$')
 
 
@@ -698,14 +793,16 @@ def handle_codex_hook():
     audit_log("codex-hook", "executed", tool_name, detail, cfg)
 
 
-def _apply_codex_session(policy: dict, cfg: dict, scope_id: str):
+def _apply_codex_session(policy: dict, cfg: dict, scope_id: str) -> dict:
     """Apply an agentnanny session policy to Codex config and rules."""
     # Determine approval_policy from profile or groups
     profile_name = policy.get("_profile_name")
     approval = CODEX_APPROVAL_MAP.get(profile_name or "", "on-request")
 
+    previous_approval = _get_codex_top_level_value("approval_policy")
     updates: dict[str, object] = {"approval_policy": approval}
     _patch_codex_config(updates)
+    suspended_mcp_modes = _suspend_codex_mcp_approval_prompts()
 
     # Generate exec policy rules from deny + allow patterns
     deny_patterns = policy.get("deny", [])
@@ -733,12 +830,25 @@ def _apply_codex_session(policy: dict, cfg: dict, scope_id: str):
         print(f"# Codex rules: {path}", file=sys.stderr)
 
     print(f"# Codex approval_policy: {approval}", file=sys.stderr)
+    if suspended_mcp_modes:
+        print(f"# Suspended MCP approval prompts: {len(suspended_mcp_modes)}", file=sys.stderr)
+    return {
+        "previous_approval_policy": previous_approval,
+        "suspended_mcp_approval_modes": suspended_mcp_modes,
+    }
 
 
-def _remove_codex_session(scope_id: str):
-    """Remove Codex artifacts for a session."""
+def _remove_codex_session(scope_id: str, prior_state: dict | None = None):
+    """Remove Codex artifacts for a session and restore prior Codex config."""
     _remove_codex_rules(scope_id)
-    _remove_codex_config_keys(["approval_policy"])
+    previous_approval = None if prior_state is None else prior_state.get("previous_approval_policy")
+    if previous_approval is None:
+        _remove_codex_config_keys(["approval_policy"])
+    else:
+        _patch_codex_config({"approval_policy": previous_approval})
+    suspended_mcp_modes = {} if prior_state is None else prior_state.get("suspended_mcp_approval_modes", {})
+    if isinstance(suspended_mcp_modes, dict):
+        _restore_codex_mcp_approval_prompts(suspended_mcp_modes)
 
 
 # ---------------------------------------------------------------------------
@@ -1819,7 +1929,8 @@ def cmd_activate(profile: str | None, groups: str | None, tools: str | None,
         print(f"# TTL: {ttl_seconds}s", file=sys.stderr)
 
     if target == "codex":
-        _apply_codex_session(policy, cfg, scope_id)
+        policy["codex_state"] = _apply_codex_session(policy, cfg, scope_id)
+        save_session_policy(policy)
 
 
 def cmd_extend(scope_id: str | None, groups: str | None, tools: str | None,
@@ -1891,12 +2002,18 @@ def cmd_deactivate(scope_id: str | None, target: str = "claude"):
     if not _valid_scope_id(scope_id):
         print(f"Invalid scope ID: {scope_id}", file=sys.stderr)
         raise SystemExit(1)
+    policy = load_session_policy(scope_id)
+    if policy is None:
+        print(f"No session policy found for {scope_id}", file=sys.stderr)
+        raise SystemExit(1)
+
+    if target == "codex":
+        _remove_codex_session(scope_id, policy.get("codex_state"))
+        print("# Removed Codex exec policy rules", file=sys.stderr)
+
     if delete_session_policy(scope_id):
-        print(f"unset AGENTNANNY_SCOPE")
+        print("unset AGENTNANNY_SCOPE")
         print(f"# Removed session {scope_id}", file=sys.stderr)
-        if target == "codex":
-            _remove_codex_session(scope_id)
-            print("# Removed Codex exec policy rules", file=sys.stderr)
     else:
         print(f"No session policy found for {scope_id}", file=sys.stderr)
         raise SystemExit(1)
@@ -1923,7 +2040,8 @@ def cmd_run(profile: str | None, groups: str | None, tools: str | None,
     env["AGENTNANNY_SCOPE"] = scope_id
 
     if target == "codex":
-        _apply_codex_session(policy, cfg, scope_id)
+        policy["codex_state"] = _apply_codex_session(policy, cfg, scope_id)
+        save_session_policy(policy)
 
     try:
         if target == "codex":
@@ -1940,9 +2058,9 @@ def cmd_run(profile: str | None, groups: str | None, tools: str | None,
         result = subprocess.run(command_args, env=env)
         raise SystemExit(result.returncode)
     finally:
-        delete_session_policy(scope_id)
         if target == "codex":
-            _remove_codex_session(scope_id)
+            _remove_codex_session(scope_id, policy.get("codex_state"))
+        delete_session_policy(scope_id)
 
 
 PROJECT_CONFIG_TEMPLATE = """\

--- a/agentnanny.py
+++ b/agentnanny.py
@@ -643,12 +643,15 @@ def _remove_all_codex_rules() -> int:
     return count
 
 
-def install_codex_hooks():
+def install_codex_hooks(*, force: bool = False):
     """Register agentnanny as a notify handler in ~/.codex/config.toml."""
     if CODEX_CONFIG_PATH.exists():
         if HOOK_MARKER in CODEX_CONFIG_PATH.read_text(encoding="utf-8"):
-            print(f"Already installed in {CODEX_CONFIG_PATH}", file=sys.stderr)
-            raise SystemExit(1)
+            if not force:
+                print(f"Already installed in {CODEX_CONFIG_PATH}", file=sys.stderr)
+                print("Use --force to reinstall", file=sys.stderr)
+                raise SystemExit(1)
+            _remove_codex_config_keys(["notify"])
 
     python_cmd = sys.executable.replace("\\", "/")
     script_path = str(SCRIPT_PATH).replace("\\", "/")
@@ -893,7 +896,19 @@ def handle_post_hook():
 HOOK_MARKER = "agentnanny"
 
 
-def install_hooks():
+def _strip_hooks_from(hooks: dict) -> None:
+    """Remove all agentnanny entries from a hooks dict (mutates in place)."""
+    for event_name in ("PermissionRequest", "PreToolUse", "PostToolUse"):
+        entries: list = hooks.get(event_name, [])
+        hooks[event_name] = [
+            entry for entry in entries
+            if not any(HOOK_MARKER in h.get("command", "") for h in entry.get("hooks", []))
+        ]
+        if not hooks[event_name]:
+            hooks.pop(event_name, None)
+
+
+def install_hooks(*, force: bool = False):
     """Register agentnanny as a PermissionRequest hook in Claude Code settings."""
     SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
     settings: dict = {}
@@ -904,11 +919,18 @@ def install_hooks():
     perm_hooks: list = hooks.setdefault("PermissionRequest", [])
 
     # Check if already installed
-    for entry in perm_hooks:
-        for h in entry.get("hooks", []):
-            if HOOK_MARKER in h.get("command", ""):
-                print(f"Already installed in {SETTINGS_PATH}", file=sys.stderr)
-                raise SystemExit(1)
+    already = any(
+        HOOK_MARKER in h.get("command", "")
+        for entry in perm_hooks
+        for h in entry.get("hooks", [])
+    )
+    if already and not force:
+        print(f"Already installed in {SETTINGS_PATH}", file=sys.stderr)
+        print("Use --force to reinstall", file=sys.stderr)
+        raise SystemExit(1)
+    if already and force:
+        # Remove existing hooks before reinstalling
+        _strip_hooks_from(hooks)
 
     script_path = str(SCRIPT_PATH)
     # Use forward slashes for cross-platform compatibility
@@ -2156,6 +2178,8 @@ def main():
     p_install = sub.add_parser("install", help="Register hooks in agent config")
     p_install.add_argument("--target", choices=TARGETS, default="claude",
                            help="Target agent (default: claude)")
+    p_install.add_argument("--force", action="store_true",
+                           help="Reinstall even if already installed")
     p_uninstall = sub.add_parser("uninstall", help="Remove hooks from agent config")
     p_uninstall.add_argument("--target", choices=TARGETS, default="claude",
                              help="Target agent (default: claude)")
@@ -2231,9 +2255,9 @@ def main():
         handle_codex_hook()
     elif args.command == "install":
         if args.target == "codex":
-            install_codex_hooks()
+            install_codex_hooks(force=args.force)
         else:
-            install_hooks()
+            install_hooks(force=args.force)
     elif args.command == "uninstall":
         if args.target == "codex":
             uninstall_codex_hooks()

--- a/agentnanny.py
+++ b/agentnanny.py
@@ -668,7 +668,9 @@ def uninstall_codex_hooks():
 
 def handle_codex_hook():
     """Codex notify hook handler. Receives tool execution info for audit logging."""
-    event = json.load(sys.stdin)
+    event = _read_hook_event()
+    if event is None:
+        return
     tool_name = event.get("tool_name", "")
     tool_input = event.get("tool_input", {})
 
@@ -757,6 +759,17 @@ def _hook_allow(tool_name: str, detail: str, cfg: dict):
     }, sys.stdout)
 
 
+def _read_hook_event() -> dict | None:
+    """Read and parse JSON hook event from stdin. Returns None on empty/malformed input."""
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
 def handle_hook():
     """PermissionRequest hook handler. Reads JSON from stdin, writes decision to stdout.
 
@@ -765,7 +778,9 @@ def handle_hook():
       - Session-scoped (AGENTNANNY_SCOPE set): loads session policy, applies its rules.
         Passthrough (no output, exit 0) when scope is missing/expired or tool not in allow list.
     """
-    event = json.load(sys.stdin)
+    event = _read_hook_event()
+    if event is None:
+        return
     tool_name = event.get("tool_name", "")
     tool_input = event.get("tool_input", {})
 
@@ -825,7 +840,9 @@ def handle_hook():
 
 def handle_post_hook():
     """PostToolUse hook handler. Monitors context pressure."""
-    event = json.load(sys.stdin)
+    event = _read_hook_event()
+    if event is None:
+        return
     tool_name = event.get("tool_name", "")
     tool_input = event.get("tool_input", {})
 

--- a/test_agentnanny.py
+++ b/test_agentnanny.py
@@ -3284,6 +3284,65 @@ class TestApplyRemoveCodexSession:
         content = config_path.read_text(encoding="utf-8")
         assert 'approval_policy = "unless-trusted"' in content
 
+    def test_apply_full_dev_sets_never(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        config_path = codex_home / "config.toml"
+        cfg = self._make_cfg()
+        policy = {
+            "_profile_name": "full-dev",
+            "deny": [],
+            "allow_groups": ["filesystem", "shell", "network"],
+            "allow_tools": [],
+        }
+
+        with patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            state = agentnanny._apply_codex_session(policy, cfg, "abc12345")
+
+        content = config_path.read_text(encoding="utf-8")
+        assert 'approval_policy = "never"' in content
+        assert state["previous_approval_policy"] is None
+
+    def test_apply_suspends_mcp_approval_modes(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        codex_home.mkdir()
+        config_path = codex_home / "config.toml"
+        config_path.write_text(
+            '\n'.join([
+                '[mcp_servers.git-tools]',
+                'enabled = true',
+                '',
+                '[mcp_servers.git-tools.tools.git_status]',
+                'approval_mode = "approve"',
+                '',
+                '[mcp_servers.tavily-remote-mcp.tools.tavily_map]',
+                'approval_mode = "approve"',
+                '',
+            ]),
+            encoding="utf-8",
+        )
+        cfg = self._make_cfg()
+        policy = {
+            "_profile_name": "full-dev",
+            "deny": [],
+            "allow_groups": ["filesystem", "shell", "network"],
+            "allow_tools": [],
+        }
+
+        with patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            state = agentnanny._apply_codex_session(policy, cfg, "abc12345")
+
+        content = config_path.read_text(encoding="utf-8")
+        assert 'approval_policy = "never"' in content
+        assert '[mcp_servers.git-tools.tools.git_status]' in content
+        assert '[mcp_servers.tavily-remote-mcp.tools.tavily_map]' in content
+        assert 'approval_mode = "approve"' not in content
+        assert state["suspended_mcp_approval_modes"] == {
+            "mcp_servers.git-tools.tools.git_status": '"approve"',
+            "mcp_servers.tavily-remote-mcp.tools.tavily_map": '"approve"',
+        }
+
     def test_apply_generates_deny_rules(self, tmp_path):
         codex_home = tmp_path / ".codex"
         config_path = codex_home / "config.toml"
@@ -3343,6 +3402,40 @@ class TestApplyRemoveCodexSession:
         assert not (rules_dir / "agentnanny-abc12345.rules").exists()
         content = config_path.read_text(encoding="utf-8")
         assert "approval_policy" not in content
+
+    def test_remove_restores_previous_approval_and_mcp_modes(self, tmp_path):
+        codex_home = tmp_path / ".codex"
+        codex_home.mkdir()
+        config_path = codex_home / "config.toml"
+        config_path.write_text(
+            '\n'.join([
+                'approval_policy = "never"',
+                '',
+                '[mcp_servers.git-tools.tools.git_status]',
+                '',
+            ]) + '\n',
+            encoding="utf-8",
+        )
+        rules_dir = codex_home / "rules"
+        rules_dir.mkdir()
+        (rules_dir / "agentnanny-abc12345.rules").write_text("# test\n")
+
+        with patch.object(agentnanny, "CODEX_HOME", codex_home), \
+             patch.object(agentnanny, "CODEX_CONFIG_PATH", config_path):
+            agentnanny._remove_codex_session(
+                "abc12345",
+                {
+                    "previous_approval_policy": "unless-trusted",
+                    "suspended_mcp_approval_modes": {
+                        "mcp_servers.git-tools.tools.git_status": '"approve"',
+                    },
+                },
+            )
+
+        content = config_path.read_text(encoding="utf-8")
+        assert 'approval_policy = "unless-trusted"' in content
+        assert '[mcp_servers.git-tools.tools.git_status]' in content
+        assert 'approval_mode = "approve"' in content
 
     def test_unknown_profile_defaults_on_request(self, tmp_path):
         codex_home = tmp_path / ".codex"


### PR DESCRIPTION
## Summary
This branch fixes the Codex session path that was still prompting for approvals under `full-dev`, hardens hook installation and hook event parsing, and updates the README to match the resulting behavior.

## Scope
This PR includes all commits on `fix/codex-approval-sessions` relative to `syd-ppt/agentnanny:master`:

- `fix(hooks): handle empty or malformed stdin in hook handlers`
- `feat(install): add --force flag for hook reinstallation`
- `fix(codex): restore no-prompt full-dev sessions`
- `docs(readme): describe codex approval behavior`

## What Changed
### Hook handler hardening
- Added `_read_hook_event()` and routed Claude and Codex hook handlers through it.
- Return cleanly when stdin is empty or malformed instead of crashing hook execution.
- This reduces failure noise during hook invocation and makes install/runtime behavior more predictable.

### Force reinstall support for hooks
- Added `--force` to `install` so existing Claude or Codex hook registrations can be replaced in place.
- For Claude installs, existing agentnanny hook entries are stripped before reinstall.
- For Codex installs, existing `notify` configuration is removed before reinstall.
- This makes recovery from stale paths or previous installs explicit and repeatable.

### Codex no-prompt session fix
- Changed the Codex approval mapping for `full-dev` and `overnight` from `on-failure` to `never`.
- During `--target codex` activation/run, agentnanny now snapshots the prior Codex approval state, applies the session approval policy, and persists that state in the session record.
- Agentnanny now suspends explicit MCP tool-level `approval_mode` overrides under `mcp_servers.*.tools.*` for the lifetime of the session so those tools inherit the active top-level approval policy instead of forcing prompts.
- On session teardown, agentnanny restores the prior top-level `approval_policy` and the prior MCP tool `approval_mode` entries.
- This closes the gap where `nanny-full-codex` still produced prompts despite a trusted, full-access session.

### Tests
- Added Codex-focused coverage for:
  - `full-dev` mapping to `approval_policy = "never"`
  - suspension of MCP tool approval overrides during Codex session activation
  - restoration of prior approval policy and MCP approval overrides on teardown

### Documentation
- Updated the README Codex mapping table to reflect `full-dev` and `overnight` using `never`.
- Documented that Codex-targeted sessions temporarily suspend MCP tool approval overrides and restore them on deactivate.

## Validation
- `uv run pytest -q test_agentnanny.py -k 'CodexApprovalMap or ApplyRemoveCodexSession or ActivateDeactivateCodex'`

## Notes
- `uv run ruff check agentnanny.py test_agentnanny.py` still reports pre-existing repository issues outside this branch's scope, including the duplicate `trust_directory` definition and unrelated test-file lint violations.
